### PR TITLE
Dleq proofs

### DIFF
--- a/api/cashu/keys.go
+++ b/api/cashu/keys.go
@@ -33,9 +33,9 @@ func GenerateKeysets(masterKey *bip32.Key, values []uint64, id string, unit Unit
 	// Format the time as a string
 	formattedTime := currentTime.Unix()
 
-	for _, value := range values {
+	for i, value := range values {
 		// uses the value it represents to derive the key
-		childKey, err := masterKey.NewChildKey(uint32(value))
+		childKey, err := masterKey.NewChildKey(uint32(i))
 		if err != nil {
 			return nil, err
 		}

--- a/api/cashu/keys_test.go
+++ b/api/cashu/keys_test.go
@@ -2,9 +2,8 @@ package cashu
 
 import (
 	"encoding/hex"
-	"testing"
-
 	"github.com/tyler-smith/go-bip32"
+	"testing"
 )
 
 func TestGenerateKeysetsAndIdGeneration(t *testing.T) {
@@ -33,7 +32,7 @@ func TestGenerateKeysetsAndIdGeneration(t *testing.T) {
 		t.Errorf("keyset unit is not Sat")
 	}
 
-	if hex.EncodeToString(generatedKeysets[0].PrivKey.PubKey().SerializeCompressed()) != "0368a33e7aad5f9983dccd05b5792d8c5f3c9e28d5cad4e448a69eead5b84b3869" {
+	if hex.EncodeToString(generatedKeysets[0].PrivKey.PubKey().SerializeCompressed()) != "03fbf65684a42313691fe562aa315f26409a19aaaaa8ef0163fc8d8598f16fe003" {
 		t.Errorf("keyset id PrivKEy is not correct. %+v", hex.EncodeToString(generatedKeysets[0].PrivKey.PubKey().SerializeCompressed()))
 	}
 
@@ -43,7 +42,7 @@ func TestGenerateKeysetsAndIdGeneration(t *testing.T) {
 		t.Errorf("could not derive keyset id %+v", err)
 	}
 
-	if keysetId != "00b7413b33e713ea" {
+	if keysetId != "0014d74f728e80b8" {
 		t.Errorf("keyset id is not correct")
 	}
 
@@ -71,7 +70,7 @@ func TestDeriveSeedsFromKey(t *testing.T) {
 		t.Errorf("seed 0 unit is not correct")
 	}
 
-	if generatedSeeds[0].Id != "00178484f5e74df9" {
+	if generatedSeeds[0].Id != "00bfa73302d12ffd" {
 		t.Errorf("seed 0 id is not correct %v", generatedSeeds[0].Id)
 	}
 

--- a/api/cashu/types.go
+++ b/api/cashu/types.go
@@ -447,6 +447,36 @@ type BlindSignatureDLEQ struct {
 	S *secp256k1.PrivateKey `json:"s"`
 }
 
+func (b *BlindSignatureDLEQ) UnmarshalJSON(data []byte) error {
+	var aux struct {
+		E string `json:"e"`
+		S string `json:"s"`
+	}
+
+	err := json.Unmarshal(data, &aux)
+	if err != nil {
+		return fmt.Errorf("json.Unmarshal: %w", err)
+	}
+
+	e_bytes, err := hex.DecodeString(aux.E)
+	if err != nil {
+		return fmt.Errorf("hex.DecodeString(aux.E): %w", err)
+	}
+
+	s_bytes, err := hex.DecodeString(aux.S)
+	if err != nil {
+		return fmt.Errorf("hex.DecodeString(aux.S): %w", err)
+	}
+
+	e := secp256k1.PrivKeyFromBytes(e_bytes)
+	s := secp256k1.PrivKeyFromBytes(s_bytes)
+
+	b.E = e
+	b.S = s
+
+	return nil
+}
+
 func (b *BlindSignatureDLEQ) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(&struct {

--- a/api/cashu/types_test.go
+++ b/api/cashu/types_test.go
@@ -3,7 +3,6 @@ package cashu
 import (
 	"encoding/hex"
 	"testing"
-
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/lescuer97/nutmix/pkg/crypto"
 	"github.com/tyler-smith/go-bip32"
@@ -89,5 +88,46 @@ func TestGenerateBlindSignatureAndCheckSignature(t *testing.T) {
 	if proof.Y != "025dccd27047d10d4900b8d2c4ea6795702c2d1fbe1d3fd0d1cd4b18776b12ddc0" {
 		t.Errorf("proof.Y is not correct")
 	}
+
+}
+
+func TestGenerateDLEQ(t *testing.T) {
+	a_bytes, err := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000001")
+	if err != nil {
+		t.Errorf("error decoding R1: %v", err)
+	}
+
+    a := secp256k1.PrivKeyFromBytes(a_bytes)
+
+    b_bytes, err := hex.DecodeString("02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2")
+    if err != nil {
+        t.Errorf("error decoding b_: %v", err)
+    }
+
+    B_, err := secp256k1.ParsePubKey(b_bytes)
+
+    if err != nil {
+        t.Errorf("secp256k1.ParsePubKey: %v", err)
+    }
+
+    C_ := "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2"
+
+    blindSignature := BlindSignature{
+        C_: C_,
+    }
+
+    err = blindSignature.GenerateDLEQ( B_, a)
+
+    if err != nil {
+        t.Errorf("could not GenerateDLEQ %+v", err)
+    }
+
+    if  blindSignature.Dleq.E.Key.String() != "9818e061ee51d5c8edc3342369a554998ff7b4381c8652d724cdf46429be73d9" {
+        t.Errorf("DLEQ.E is not correct %+v", blindSignature.Dleq.E.Key.String())
+    }
+
+    if blindSignature.Dleq.S.Key.String() != "9818e061ee51d5c8edc3342369a554998ff7b4381c8652d724cdf46429be73da" {
+        t.Errorf("DLEQ.S is not correct %+v", blindSignature.Dleq.S.Key.String())
+    }
 
 }

--- a/api/cashu/types_test.go
+++ b/api/cashu/types_test.go
@@ -127,8 +127,6 @@ func TestGenerateDLEQ(t *testing.T) {
 		t.Errorf("could not VerifyDLEQ %+v", err)
 	}
 
-	fmt.Println("verify: ", verify)
-
 	if !verify {
 		t.Errorf("DLEQ is not correct")
 	}

--- a/api/cashu/types_test.go
+++ b/api/cashu/types_test.go
@@ -3,10 +3,10 @@ package cashu
 import (
 	"encoding/hex"
 	"fmt"
-	"testing"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/lescuer97/nutmix/pkg/crypto"
 	"github.com/tyler-smith/go-bip32"
+	"testing"
 )
 
 func TestGenerateBlindSignatureAndCheckSignature(t *testing.T) {

--- a/api/cashu/types_test.go
+++ b/api/cashu/types_test.go
@@ -53,11 +53,11 @@ func TestGenerateBlindSignatureAndCheckSignature(t *testing.T) {
 		t.Errorf("could GenerateBlindSignature %+v", err)
 	}
 
-	if blindSignature.C_ != "02911a413c227c35f235517dc87432c2d9b0cba66766245f632be8e185de58af92" {
+	if blindSignature.C_ != "024b60ff45c5a4ef4630072a03eaabcb948beae56d034a3bba68dc8cda68845c5d" {
 		t.Errorf("blindSignature is not correct")
 	}
 
-	if blindSignature.Id != "00b7413b33e713ea" {
+	if blindSignature.Id != "0014d74f728e80b8" {
 		t.Errorf("blindSignature id is not correct")
 	}
 

--- a/api/cashu/types_test.go
+++ b/api/cashu/types_test.go
@@ -2,6 +2,7 @@ package cashu
 
 import (
 	"encoding/hex"
+	"fmt"
 	"testing"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/lescuer97/nutmix/pkg/crypto"
@@ -97,37 +98,39 @@ func TestGenerateDLEQ(t *testing.T) {
 		t.Errorf("error decoding R1: %v", err)
 	}
 
-    a := secp256k1.PrivKeyFromBytes(a_bytes)
+	a := secp256k1.PrivKeyFromBytes(a_bytes)
 
-    b_bytes, err := hex.DecodeString("02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2")
-    if err != nil {
-        t.Errorf("error decoding b_: %v", err)
-    }
+	b_bytes, err := hex.DecodeString("02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2")
+	if err != nil {
+		t.Errorf("error decoding b_: %v", err)
+	}
 
-    B_, err := secp256k1.ParsePubKey(b_bytes)
+	B_, err := secp256k1.ParsePubKey(b_bytes)
 
-    if err != nil {
-        t.Errorf("secp256k1.ParsePubKey: %v", err)
-    }
+	if err != nil {
+		t.Errorf("secp256k1.ParsePubKey: %v", err)
+	}
 
-    C_ := "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2"
+	C_ := "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2"
 
-    blindSignature := BlindSignature{
-        C_: C_,
-    }
+	blindSignature := BlindSignature{
+		C_: C_,
+	}
 
-    err = blindSignature.GenerateDLEQ( B_, a)
+	err = blindSignature.GenerateDLEQ(B_, a)
+	if err != nil {
+		t.Errorf("could not GenerateDLEQ %+v", err)
+	}
 
-    if err != nil {
-        t.Errorf("could not GenerateDLEQ %+v", err)
-    }
+	verify, err := blindSignature.VerifyDLEQ(B_, blindSignature.Dleq.E, blindSignature.Dleq.S, a.PubKey())
+	if err != nil {
+		t.Errorf("could not VerifyDLEQ %+v", err)
+	}
 
-    if  blindSignature.Dleq.E.Key.String() != "9818e061ee51d5c8edc3342369a554998ff7b4381c8652d724cdf46429be73d9" {
-        t.Errorf("DLEQ.E is not correct %+v", blindSignature.Dleq.E.Key.String())
-    }
+	fmt.Println("verify: ", verify)
 
-    if blindSignature.Dleq.S.Key.String() != "9818e061ee51d5c8edc3342369a554998ff7b4381c8652d724cdf46429be73da" {
-        t.Errorf("DLEQ.S is not correct %+v", blindSignature.Dleq.S.Key.String())
-    }
+	if !verify {
+		t.Errorf("DLEQ is not correct")
+	}
 
 }

--- a/api/cashu/util_test.go
+++ b/api/cashu/util_test.go
@@ -1,9 +1,8 @@
 package cashu
 
 import (
-	"testing"
-
 	"github.com/tyler-smith/go-bip32"
+	"testing"
 )
 
 func TestOrderKeysetByUnit(t *testing.T) {
@@ -24,7 +23,7 @@ func TestOrderKeysetByUnit(t *testing.T) {
 
 	firstOrdKey := orderedKeys["keysets"][0]
 
-	if firstOrdKey.Keys["1"] != "0368a33e7aad5f9983dccd05b5792d8c5f3c9e28d5cad4e448a69eead5b84b3869" {
+	if firstOrdKey.Keys["1"] != "03fbf65684a42313691fe562aa315f26409a19aaaaa8ef0163fc8d8598f16fe003" {
 		t.Errorf("keyset is not correct")
 	}
 

--- a/cmd/nutmix/main_test.go
+++ b/cmd/nutmix/main_test.go
@@ -495,7 +495,6 @@ func TestMintBolt11FakeWallet(t *testing.T) {
 	w = httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	fmt.Printf("BODY %+v", w)
 	if w.Code != 403 {
 		t.Errorf("Expected status code 403, got %d", w.Code)
 	}

--- a/internal/lightning/invoice.go
+++ b/internal/lightning/invoice.go
@@ -56,7 +56,7 @@ func mppPaymentHashAndPreimage(d *invoicesrpc.AddInvoiceData) (*lntypes.Preimage
 	return paymentPreimage, paymentHash, nil
 }
 
-func CreateMockInvoice(amountSats int64, description string, network chaincfg.Params) (string, error) {
+func CreateMockInvoice(amountSats int64, description string, network chaincfg.Params, expiry int64) (string, error) {
 	milsats, err := lnrpc.UnmarshallAmt(amountSats, 0)
 	if err != nil {
 		return "", fmt.Errorf("UnmarshallAmt: %w", err)
@@ -66,7 +66,7 @@ func CreateMockInvoice(amountSats int64, description string, network chaincfg.Pa
 		Memo:     description,
 		Value:    milsats,
 		Preimage: nil,
-		Expiry:   3600,
+		Expiry:   expiry,
 		Private:  false,
 		Hash:     nil,
 	}

--- a/internal/mint/mint_test.go
+++ b/internal/mint/mint_test.go
@@ -47,7 +47,7 @@ func TestSetUpMint(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not setup master key %+v", err)
 	}
-	childKey, err := masterKey.NewChildKey(1)
+	childKey, err := masterKey.NewChildKey(0)
 	if err != nil {
 		t.Errorf("could not set lightning backend %v", err)
 	}
@@ -59,7 +59,7 @@ func TestSetUpMint(t *testing.T) {
 	}
 
 	// compare keys for value 2 sat
-	childKeyTwo, err := masterKey.NewChildKey(2)
+	childKeyTwo, err := masterKey.NewChildKey(1)
 	if err != nil {
 		t.Errorf("could not set lightning backend %v", err)
 	}
@@ -67,16 +67,5 @@ func TestSetUpMint(t *testing.T) {
 
 	if mint.ActiveKeysets[cashu.Sat.String()][2].PrivKey.Key.String() != privKeyTwo.Key.String() {
 		t.Errorf("Keys are not the same. \n\n Should be: %x  \n\n Is: %x ", privKeyTwo.Key.String(), mint.ActiveKeysets[cashu.Sat.String()][2].PrivKey.Key.String())
-	}
-
-	// checks for the last key available in the keyset
-	childKeyLast, err := masterKey.NewChildKey(131072)
-	if err != nil {
-		t.Errorf("could not set lightning backend %v", err)
-	}
-	privKeyLast := secp256k1.PrivKeyFromBytes(childKeyLast.Key)
-
-	if mint.ActiveKeysets[cashu.Sat.String()][131072].PrivKey.Key.String() != privKeyLast.Key.String() {
-		t.Errorf("Keys are not the same. \n\n Should be: %x  \n\n Is: %x ", privKeyLast.Key.String(), mint.ActiveKeysets[cashu.Sat.String()][131072].PrivKey.Key.String())
 	}
 }

--- a/internal/routes/bolt11.go
+++ b/internal/routes/bolt11.go
@@ -48,7 +48,7 @@ func v1bolt11Routes(r *gin.Engine, pool *pgxpool.Pool, mint mint.Mint) {
 
 		switch lightningBackendType {
 		case comms.FAKE_WALLET:
-			payReq, err := lightning.CreateMockInvoice(mintRequest.Amount, "mock invoice", mint.Network)
+			payReq, err := lightning.CreateMockInvoice(mintRequest.Amount, "mock invoice", mint.Network, cashu.ExpiryTime)
 			if err != nil {
 				log.Println(err)
 				c.JSON(500, "Opps!, something went wrong")

--- a/internal/routes/mint.go
+++ b/internal/routes/mint.go
@@ -98,7 +98,7 @@ func v1MintRoutes(r *gin.Engine, pool *pgxpool.Pool, mint mint.Mint) {
 		}
 
 		nuts := make(map[string]cashu.SwapMintInfo)
-		var activeNuts []string = []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"}
+		var activeNuts []string = []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"}
 
 		for _, nut := range activeNuts {
 			nuts[nut] = cashu.SwapMintInfo{

--- a/pkg/crypto/bdhke.go
+++ b/pkg/crypto/bdhke.go
@@ -126,7 +126,7 @@ func verify(Y *secp256k1.PublicKey, k *secp256k1.PrivateKey, C *secp256k1.Public
 }
 
 // DLEQ HASH
-func Hash_e(pubkeys []*secp256k1.PublicKey) ([32]byte, error) {
+func Hash_e(pubkeys []*secp256k1.PublicKey) [32]byte {
 	e_ := ""
 	for _, pubkey := range pubkeys {
 		_p := pubkey.SerializeUncompressed()
@@ -138,5 +138,5 @@ func Hash_e(pubkeys []*secp256k1.PublicKey) ([32]byte, error) {
 
 	e := sha256.Sum256(e_bytes)
 
-	return e, nil
+	return e
 }

--- a/pkg/crypto/bdhke.go
+++ b/pkg/crypto/bdhke.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"math"
 
@@ -122,4 +123,20 @@ func verify(Y *secp256k1.PublicKey, k *secp256k1.PrivateKey, C *secp256k1.Public
 	pk := secp256k1.NewPublicKey(&result.X, &result.Y)
 
 	return C.IsEqual(pk)
+}
+
+// DLEQ HASH
+func Hash_e(pubkeys []*secp256k1.PublicKey) ([32]byte, error) {
+	e_ := ""
+	for _, pubkey := range pubkeys {
+		_p := pubkey.SerializeUncompressed()
+
+		e_ += hex.EncodeToString(_p)
+	}
+
+	e_bytes := []byte(e_)
+
+	e := sha256.Sum256(e_bytes)
+
+	return e, nil
 }

--- a/pkg/crypto/bdhke_test.go
+++ b/pkg/crypto/bdhke_test.go
@@ -173,7 +173,6 @@ func TestHashE(t *testing.T) {
 	if err != nil {
 		t.Errorf("error decoding R1: %v", err)
 	}
-	// fmt.Println(" len  ", len(R1Bytes))
 	R1, error := secp256k1.ParsePubKey(R1Bytes)
 	if error != nil {
 		t.Errorf("error parsing R1: %v", error)

--- a/pkg/crypto/bdhke_test.go
+++ b/pkg/crypto/bdhke_test.go
@@ -2,10 +2,9 @@ package crypto
 
 import (
 	"encoding/hex"
-	"testing"
-
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"testing"
 )
 
 func TestHashToCurve(t *testing.T) {
@@ -167,4 +166,57 @@ func TestVerify(t *testing.T) {
 	if !Verify(secret, k, C) {
 		t.Error("failed verification")
 	}
+}
+
+func TestHashE(t *testing.T) {
+	R1Bytes, err := hex.DecodeString("020000000000000000000000000000000000000000000000000000000000000001")
+	if err != nil {
+		t.Errorf("error decoding R1: %v", err)
+	}
+	// fmt.Println(" len  ", len(R1Bytes))
+	R1, error := secp256k1.ParsePubKey(R1Bytes)
+	if error != nil {
+		t.Errorf("error parsing R1: %v", error)
+	}
+
+	R2Bytes, err := hex.DecodeString("020000000000000000000000000000000000000000000000000000000000000001")
+	if error != nil {
+		t.Errorf("error parsing R1: %v", error)
+	}
+	R2, error := secp256k1.ParsePubKey(R2Bytes)
+	if error != nil {
+		t.Errorf("error parsing R2: %v", error)
+	}
+
+	KBytes, err := hex.DecodeString("020000000000000000000000000000000000000000000000000000000000000001")
+	if error != nil {
+		t.Errorf("error parsing K: %v", error)
+	}
+	K, error := secp256k1.ParsePubKey(KBytes)
+
+	if error != nil {
+		t.Errorf("error parsing R1: %v", error)
+	}
+
+	C_Bytes, err := hex.DecodeString("02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2")
+	if error != nil {
+		t.Errorf("error parsing C_: %v", error)
+	}
+
+	C_, error := secp256k1.ParsePubKey(C_Bytes)
+	if error != nil {
+		t.Errorf("error parsing C_: %v", error)
+	}
+	keys := []*secp256k1.PublicKey{R1, R2, K, C_}
+
+	hash, err := Hash_e(keys)
+
+	if err != nil {
+		t.Errorf("error hashing: %v", err)
+	}
+
+	if hex.EncodeToString(hash[:]) != "a4dc034b74338c28c6bc3ea49731f2a24440fc7c4affc08b31a93fc9fbe6401e" {
+        t.Errorf("hash is not correct. got: \n\n %v", hex.EncodeToString(hash[:]))
+	}
+
 }

--- a/pkg/crypto/bdhke_test.go
+++ b/pkg/crypto/bdhke_test.go
@@ -209,14 +209,10 @@ func TestHashE(t *testing.T) {
 	}
 	keys := []*secp256k1.PublicKey{R1, R2, K, C_}
 
-	hash, err := Hash_e(keys)
-
-	if err != nil {
-		t.Errorf("error hashing: %v", err)
-	}
+	hash := Hash_e(keys)
 
 	if hex.EncodeToString(hash[:]) != "a4dc034b74338c28c6bc3ea49731f2a24440fc7c4affc08b31a93fc9fbe6401e" {
-        t.Errorf("hash is not correct. got: \n\n %v", hex.EncodeToString(hash[:]))
+		t.Errorf("hash is not correct. got: \n\n %v", hex.EncodeToString(hash[:]))
 	}
 
 }


### PR DESCRIPTION
Apply DLEQ proofs to BlindSignatures and Verification function for testing. 
Other fixes:
- Fix bug on key generation. when derivation key value would exceed 32bits it would just use the top value this would lead to repeated keys change to use index of list of amounts intead of the values of the actual amounts.
- Fixed expiration on lightning mock invoice
