### PR TITLE
Lock active proofs being used and quotes

### DIFF
--- a/cmd/nutmix/main.go
+++ b/cmd/nutmix/main.go
@@ -150,7 +150,7 @@ func main() {
 
 	r.Use(cors.Default())
 
-	routes.V1Routes(ctx, r, pool, mint)
+	routes.V1Routes(ctx, r, pool, &mint)
 
 	defer pool.Close()
 

--- a/cmd/nutmix/main_test.go
+++ b/cmd/nutmix/main_test.go
@@ -649,7 +649,7 @@ func SetupRoutingForTesting(ctx context.Context) (*gin.Engine, mint.Mint) {
 
 	r := gin.Default()
 
-	routes.V1Routes(ctx, r, pool, mint)
+	routes.V1Routes(ctx, r, pool, &mint)
 
 	return r, mint
 }

--- a/internal/routes/mint.go
+++ b/internal/routes/mint.go
@@ -17,7 +17,7 @@ import (
 	"github.com/tyler-smith/go-bip32"
 )
 
-func v1MintRoutes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint mint.Mint) {
+func v1MintRoutes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint *mint.Mint) {
 	v1 := r.Group("/v1")
 
 	v1.GET("/keys", func(c *gin.Context) {
@@ -64,6 +64,9 @@ func v1MintRoutes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint m
 	})
 
 	v1.GET("/info", func(c *gin.Context) {
+
+		fmt.Printf("Active Swaps: %v\n", len(mint.ActiveProofs.Proofs))
+		fmt.Printf("Active Mint: %v\n", len(mint.ActiveQuotes.Quote))
 
 		seed, err := database.GetActiveSeed(pool)
 
@@ -175,21 +178,31 @@ func v1MintRoutes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint m
 		}
 
 		if len(knownProofs) != 0 {
-			log.Printf("Proofs already used: %+v", knownProofs)
 			c.JSON(400, "Proofs already used")
+			return
+		}
+
+		err = mint.AddProofs(swapRequest.Inputs)
+
+		if err != nil {
+			log.Printf("mint.AddProof: %+v", err)
+			c.JSON(400, "Proofs are already in use")
 			return
 		}
 
 		unit, err := mint.CheckProofsAreSameUnit(swapRequest.Inputs)
 
 		if err != nil {
+			mint.RemoveProofs(swapRequest.Inputs)
 			log.Printf("CheckProofsAreSameUnit: %+v", err)
 			c.JSON(400, "Proofs are not the same unit")
 			return
 		}
+
 		err = mint.VerifyListOfProofs(swapRequest.Inputs, swapRequest.Outputs, unit)
 
 		if err != nil {
+			mint.RemoveProofs(swapRequest.Inputs)
 			log.Println(fmt.Errorf("mint.VerifyListOfProofs: %w", err))
 
 			switch {
@@ -213,6 +226,7 @@ func v1MintRoutes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint m
 		blindedSignatures, recoverySigsDb, err := mint.SignBlindedMessages(swapRequest.Outputs, cashu.Sat.String())
 
 		if err != nil {
+			mint.RemoveProofs(swapRequest.Inputs)
 			log.Println(fmt.Errorf("mint.SignBlindedMessages: %w", err))
 			c.JSON(500, "Opps!, something went wrong")
 			return
@@ -226,11 +240,14 @@ func v1MintRoutes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint m
 		err = database.SaveProofs(pool, swapRequest.Inputs)
 
 		if err != nil {
+			mint.RemoveProofs(swapRequest.Inputs)
 			log.Println(fmt.Errorf("SaveProofs: %w", err))
 			log.Println(fmt.Errorf("Proofs: %+v", swapRequest.Inputs))
 			c.JSON(200, response)
 			return
 		}
+
+		mint.RemoveProofs(swapRequest.Inputs)
 
 		err = database.SetRestoreSigs(pool, recoverySigsDb)
 		if err != nil {

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lescuer97/nutmix/internal/mint"
 )
 
-func V1Routes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint mint.Mint) {
+func V1Routes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint *mint.Mint) {
 	v1MintRoutes(ctx, r, pool, mint)
 	v1bolt11Routes(ctx, r, pool, mint)
 


### PR DESCRIPTION
Make mutex locks variables for storing proofs and quotes being used at the time. 

This are cleared either at the end of a call or when an error happens.

this fixes #54 