### PR TITLE
Htlc support

### DIFF
--- a/api/cashu/spend_condition.go
+++ b/api/cashu/spend_condition.go
@@ -418,10 +418,9 @@ func (wit *Witness) String() (string, error) {
 		witness.Signatures = append(witness.Signatures, hex.EncodeToString(sig.Serialize()))
 	}
 
-    if wit.Preimage != "" {
-        witness.Preimage = wit.Preimage
-    }
-
+	if wit.Preimage != "" {
+		witness.Preimage = wit.Preimage
+	}
 
 	b, err := json.Marshal(witness)
 	if err != nil {
@@ -432,23 +431,22 @@ func (wit *Witness) String() (string, error) {
 
 func (wit *Witness) UnmarshalJSON(b []byte) error {
 	var sigs = struct {
-		Preimage    string
+		Preimage   string
 		Signatures []string
 	}{}
 
-    err := json.Unmarshal(b, &sigs)
+	err := json.Unmarshal(b, &sigs)
 
 	if err != nil {
 		return fmt.Errorf("json.Unmarshal(b, &info): %w", err)
 	}
 
-
 	witness := Witness{
 		Signatures: make([]*schnorr.Signature, 0),
 	}
-    if sigs.Preimage != "" {
-        witness.Preimage = sigs.Preimage
-    }
+	if sigs.Preimage != "" {
+		witness.Preimage = sigs.Preimage
+	}
 
 	for _, sig := range sigs.Signatures {
 		sigBytes, err := hex.DecodeString(sig)

--- a/api/cashu/spend_condition.go
+++ b/api/cashu/spend_condition.go
@@ -418,6 +418,11 @@ func (wit *Witness) String() (string, error) {
 		witness.Signatures = append(witness.Signatures, hex.EncodeToString(sig.Serialize()))
 	}
 
+    if wit.Preimage != "" {
+        witness.Preimage = wit.Preimage
+    }
+
+
 	b, err := json.Marshal(witness)
 	if err != nil {
 		return "", fmt.Errorf("json.Marshal(singatures): %w", err)
@@ -426,22 +431,24 @@ func (wit *Witness) String() (string, error) {
 }
 
 func (wit *Witness) UnmarshalJSON(b []byte) error {
-
 	var sigs = struct {
-		Witness    string
+		Preimage    string
 		Signatures []string
 	}{}
 
-	err := json.Unmarshal(b, &sigs)
+    err := json.Unmarshal(b, &sigs)
 
 	if err != nil {
 		return fmt.Errorf("json.Unmarshal(b, &info): %w", err)
 	}
 
+
 	witness := Witness{
-		Preimage:   sigs.Witness,
 		Signatures: make([]*schnorr.Signature, 0),
 	}
+    if sigs.Preimage != "" {
+        witness.Preimage = sigs.Preimage
+    }
 
 	for _, sig := range sigs.Signatures {
 		sigBytes, err := hex.DecodeString(sig)

--- a/api/cashu/spend_condition.go
+++ b/api/cashu/spend_condition.go
@@ -28,6 +28,8 @@ var (
 	ErrNoValidSignatures             = errors.New("No valid signatures found")
 	ErrNotEnoughSignatures           = errors.New("Not enough signatures")
 	ErrLocktimePassed                = errors.New("Locktime has passed and no refund key was found")
+	ErrInvalidHexPreimage            = errors.New("Preimage is not a valid hex string")
+	ErrInvalidPreimage               = errors.New("Invalid preimage")
 )
 
 type SpendCondition struct {
@@ -69,7 +71,7 @@ func (sc *SpendCondition) String() (string, error) {
 
 	str += fmt.Sprintf("\"%s\",", typestr)
 	str += fmt.Sprintf(`{"nonce":"%s",`, sc.Data.Nonce)
-	str += fmt.Sprintf(`"data":"%s",`, hex.EncodeToString(sc.Data.Data.SerializeCompressed()))
+	str += fmt.Sprintf(`"data":"%s",`, sc.Data.Data)
 	str += fmt.Sprintf(`"tags":[`)
 	str += fmt.Sprintf(`["sigflag","%s"],`, sc.Data.Tags.Sigflag.String())
 	str += fmt.Sprintf(`["n_sigs","%s"],`, strconv.Itoa(sc.Data.Tags.NSigs))
@@ -241,37 +243,22 @@ func (tags *TagsInfo) UnmarshalJSON(b []byte) error {
 
 type SpendConditionData struct {
 	Nonce string
-	Data  *btcec.PublicKey
+	Data  string
 	Tags  TagsInfo
 }
 
-func (scd *SpendConditionData) UnmarshalJSON(b []byte) error {
-
-	var info = struct {
-		Nonce string
-		Data  string
-		Tags  TagsInfo
-	}{}
-
-	err := json.Unmarshal(b, &info)
+func (sc *SpendCondition) VerifyPreimage(witness *Witness) error {
+	preImageBytes, err := hex.DecodeString(witness.Preimage)
 
 	if err != nil {
-		return fmt.Errorf("json.Unmarshal(b, &info): %w", err)
+		return fmt.Errorf("hex.DecodeString: %w, %w", ErrInvalidHexPreimage, err)
 	}
 
-	pubkey, err := hex.DecodeString(info.Data)
-	if err != nil {
-		return fmt.Errorf("hex.DecodeString: %s %w", info.Data, err)
-	}
+	parsedPreimage := sha256.Sum256(preImageBytes)
 
-	parsedPubkey, err := btcec.ParsePubKey(pubkey)
-	if err != nil {
-		return fmt.Errorf("secp256k1.ParsePubKey: %w", err)
+	if hex.EncodeToString(parsedPreimage[:]) != sc.Data.Data {
+		return ErrInvalidPreimage
 	}
-
-	scd.Data = parsedPubkey
-	scd.Tags = info.Tags
-	scd.Nonce = info.Nonce
 
 	return nil
 
@@ -282,7 +269,24 @@ func (sc *SpendCondition) VerifySignatures(witness *Witness, message string) (bo
 	currentTime := time.Now().Unix()
 
 	hashMessage := sha256.Sum256([]byte(message))
-	signaturesToTry := append(sc.Data.Tags.Pubkeys, sc.Data.Data)
+
+	signaturesToTry := sc.Data.Tags.Pubkeys
+
+	if sc.Type == P2PK {
+
+		pubkey, err := hex.DecodeString(sc.Data.Data)
+
+		if err != nil {
+			return false, sc.Data.Tags.Pubkeys, ErrNoValidSignatures
+		}
+		//
+		parsedPubkey, err := btcec.ParsePubKey(pubkey)
+		if err != nil {
+			return false, sc.Data.Tags.Pubkeys, ErrNoValidSignatures
+		}
+
+		signaturesToTry = append(signaturesToTry, parsedPubkey)
+	}
 
 	// check if locktime has passed and if there are refund keys
 	if sc.Data.Tags.Locktime != 0 && currentTime > int64(sc.Data.Tags.Locktime) && len(sc.Data.Tags.Refund) > 0 {

--- a/api/cashu/spend_condition_test.go
+++ b/api/cashu/spend_condition_test.go
@@ -43,8 +43,8 @@ func TestParseProofWithP2PK(t *testing.T) {
 		t.Errorf("Error in spend condition type %+v", spendCondition.Type)
 	}
 
-	if hex.EncodeToString(spendCondition.Data.Data.SerializeCompressed()) != "0275c5c0ddafea52d669f09de48da03896d09962d6d4e545e94f573d52840f04ae" {
-		t.Errorf("Error in spend condition data %+v", hex.EncodeToString(spendCondition.Data.Data.SerializeUncompressed()))
+	if spendCondition.Data.Data != "0275c5c0ddafea52d669f09de48da03896d09962d6d4e545e94f573d52840f04ae" {
+		t.Errorf("Error in spend condition data %+v", spendCondition.Data.Data)
 	}
 
 	if hex.EncodeToString(spendCondition.Data.Tags.Pubkeys[0].SerializeCompressed()) != "02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904" {

--- a/api/cashu/spend_condition_test.go
+++ b/api/cashu/spend_condition_test.go
@@ -55,7 +55,7 @@ func TestParseProofWithP2PK(t *testing.T) {
 		t.Errorf("Error in spend condition refund %+v", hex.EncodeToString(spendCondition.Data.Tags.Refund[0].SerializeUncompressed()))
 	}
 
-	var p2pkWitness P2PKWitness
+	var p2pkWitness Witness
 	// parse witness
 	err = json.Unmarshal([]byte(proof.Witness), &p2pkWitness)
 
@@ -69,3 +69,9 @@ func TestParseProofWithP2PK(t *testing.T) {
 
 	}
 }
+
+// func TestParseProofWithHTLC(t *testing.T) {
+//
+//     parse :=
+//
+// }

--- a/api/cashu/types.go
+++ b/api/cashu/types.go
@@ -155,6 +155,13 @@ type Proof struct {
 
 func (p Proof) VerifyWitness(spendCondition *SpendCondition, witness *Witness, pubkeysFromProofs *map[*btcec.PublicKey]bool) (bool, error) {
 
+	if spendCondition.Type == HTLC {
+       err :=  spendCondition.VerifyPreimage(witness)
+       if err != nil {
+           return false, fmt.Errorf("spendCondition.VerifyPreimage  %w ", err)
+       }
+	}
+
 	ok, pubkeys, err := spendCondition.VerifySignatures(witness, p.Secret)
 
 	if err != nil {

--- a/api/cashu/types.go
+++ b/api/cashu/types.go
@@ -267,6 +267,29 @@ func (p *Proof) Sign(privkey *secp256k1.PrivateKey) error {
 	p.Witness = witnessStr
 	return nil
 }
+func (p *Proof) AddPreimage(preimage string ) error {
+
+	var witness Witness
+	if p.Witness == "" {
+		witness = Witness{}
+	} else {
+        err := json.Unmarshal([]byte(p.Witness), &witness)
+		if err != nil {
+			return fmt.Errorf("json.Unmarshal([]byte(p.Witness), &witness)  %w, %w", ErrCouldNotParseWitness, err)
+		}
+	}
+
+    witness.Preimage = preimage
+
+	witnessStr, err := witness.String()
+
+	if err != nil {
+		return fmt.Errorf("witness.String: %w", err)
+	}
+
+	p.Witness = witnessStr
+	return nil
+}
 
 type MintError struct {
 	Detail string `json:"detail"`

--- a/api/cashu/types.go
+++ b/api/cashu/types.go
@@ -156,10 +156,10 @@ type Proof struct {
 func (p Proof) VerifyWitness(spendCondition *SpendCondition, witness *Witness, pubkeysFromProofs *map[*btcec.PublicKey]bool) (bool, error) {
 
 	if spendCondition.Type == HTLC {
-       err :=  spendCondition.VerifyPreimage(witness)
-       if err != nil {
-           return false, fmt.Errorf("spendCondition.VerifyPreimage  %w ", err)
-       }
+		err := spendCondition.VerifyPreimage(witness)
+		if err != nil {
+			return false, fmt.Errorf("spendCondition.VerifyPreimage  %w ", err)
+		}
 	}
 
 	ok, pubkeys, err := spendCondition.VerifySignatures(witness, p.Secret)
@@ -267,19 +267,19 @@ func (p *Proof) Sign(privkey *secp256k1.PrivateKey) error {
 	p.Witness = witnessStr
 	return nil
 }
-func (p *Proof) AddPreimage(preimage string ) error {
+func (p *Proof) AddPreimage(preimage string) error {
 
 	var witness Witness
 	if p.Witness == "" {
 		witness = Witness{}
 	} else {
-        err := json.Unmarshal([]byte(p.Witness), &witness)
+		err := json.Unmarshal([]byte(p.Witness), &witness)
 		if err != nil {
 			return fmt.Errorf("json.Unmarshal([]byte(p.Witness), &witness)  %w, %w", ErrCouldNotParseWitness, err)
 		}
 	}
 
-    witness.Preimage = preimage
+	witness.Preimage = preimage
 
 	witnessStr, err := witness.String()
 

--- a/api/cashu/types.go
+++ b/api/cashu/types.go
@@ -70,7 +70,7 @@ func (b BlindedMessage) VerifyBlindMessageSignature(pubkeys map[*btcec.PublicKey
 	if b.Witness == "" {
 		return ErrEmptyWitness
 	}
-	var p2pkWitness P2PKWitness
+	var p2pkWitness Witness
 
 	err := json.Unmarshal([]byte(b.Witness), &p2pkWitness)
 
@@ -153,7 +153,7 @@ type Proof struct {
 	Witness string `json:"witness" db:"witness"`
 }
 
-func (p Proof) VerifyWitnessSig(spendCondition *SpendCondition, witness *P2PKWitness, pubkeysFromProofs *map[*btcec.PublicKey]bool) (bool, error) {
+func (p Proof) VerifyWitness(spendCondition *SpendCondition, witness *Witness, pubkeysFromProofs *map[*btcec.PublicKey]bool) (bool, error) {
 
 	ok, pubkeys, err := spendCondition.VerifySignatures(witness, p.Secret)
 
@@ -169,10 +169,10 @@ func (p Proof) VerifyWitnessSig(spendCondition *SpendCondition, witness *P2PKWit
 
 }
 
-func (p Proof) parseWitnessAndSecret() (*SpendCondition, *P2PKWitness, error) {
+func (p Proof) parseWitnessAndSecret() (*SpendCondition, *Witness, error) {
 
 	var spendCondition SpendCondition
-	var witness P2PKWitness
+	var witness Witness
 
 	err := json.Unmarshal([]byte(p.Secret), &spendCondition)
 
@@ -191,8 +191,8 @@ func (p Proof) parseWitnessAndSecret() (*SpendCondition, *P2PKWitness, error) {
 	return &spendCondition, &witness, nil
 }
 
-func (p Proof) IsProofSpendConditioned(checkOutputs *bool) (bool, *SpendCondition, *P2PKWitness, error) {
-	var witness P2PKWitness
+func (p Proof) IsProofSpendConditioned(checkOutputs *bool) (bool, *SpendCondition, *Witness, error) {
+	var witness Witness
 	witnessErr := json.Unmarshal([]byte(p.Witness), &witness)
 
 	var spendCondition SpendCondition
@@ -239,9 +239,9 @@ func (p *Proof) Sign(privkey *secp256k1.PrivateKey) error {
 		return fmt.Errorf("schnorr.Sign: %w", err)
 	}
 
-	var witness P2PKWitness
+	var witness Witness
 	if p.Witness == "" {
-		witness = P2PKWitness{}
+		witness = Witness{}
 	} else {
 		err = json.Unmarshal([]byte(p.Witness), &witness)
 		if err != nil {

--- a/cmd/nutmix/htlc_route_test.go
+++ b/cmd/nutmix/htlc_route_test.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/nutmix/htlc_route_test.go
+++ b/cmd/nutmix/htlc_route_test.go
@@ -1,1 +1,588 @@
 package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/lescuer97/nutmix/api/cashu"
+	"github.com/lescuer97/nutmix/internal/database"
+	"github.com/lescuer97/nutmix/internal/mint"
+	"github.com/lescuer97/nutmix/pkg/crypto"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+var correctPreimage = hex.EncodeToString([]byte("12345"))
+
+func TestRoutesHTLCSwapMelt(t *testing.T) {
+	const posgrespassword = "password"
+	const postgresuser = "user"
+	ctx := context.Background()
+
+	postgresContainer, err := postgres.RunContainer(ctx,
+		testcontainers.WithImage("postgres:16.2"),
+		postgres.WithDatabase("postgres"),
+		postgres.WithUsername(postgresuser),
+		postgres.WithPassword(posgrespassword),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(5*time.Second)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	connUri, err := postgresContainer.ConnectionString(ctx)
+
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to get connection string: %w", err))
+	}
+
+	os.Setenv("DATABASE_URL", connUri)
+	os.Setenv("MINT_PRIVATE_KEY", MintPrivateKey)
+	os.Setenv("MINT_LIGHTNING_BACKEND", "FakeWallet")
+	os.Setenv(mint.NETWORK_ENV, "regtest")
+
+	ctx = context.WithValue(ctx, mint.NETWORK_ENV, os.Getenv(mint.NETWORK_ENV))
+	ctx = context.WithValue(ctx, mint.MINT_LIGHTNING_BACKEND_ENV, os.Getenv(mint.MINT_LIGHTNING_BACKEND_ENV))
+	ctx = context.WithValue(ctx, database.DATABASE_URL_ENV, os.Getenv(database.DATABASE_URL_ENV))
+	ctx = context.WithValue(ctx, mint.NETWORK_ENV, os.Getenv(mint.NETWORK_ENV))
+
+	router, mint := SetupRoutingForTesting(ctx)
+
+	lockingPrivKey := secp256k1.PrivKeyFromBytes([]byte{0x01, 0x02, 0x03, 0x04})
+
+	wrongPrivKey := secp256k1.PrivKeyFromBytes([]byte{0x01, 0x02, 0x03, 0x05})
+
+	if err != nil {
+		t.Fatalf("could not parse locking pubkey: %v", err)
+	}
+
+	// MINTING TESTING STARTS
+	// request mint quote of 1000 sats
+	w := httptest.NewRecorder()
+
+	mintQuoteRequest := cashu.PostMintQuoteBolt11Request{
+		Amount: 1000,
+		Unit:   cashu.Sat.String(),
+	}
+	jsonRequestBody, _ := json.Marshal(mintQuoteRequest)
+
+	req := httptest.NewRequest("POST", "/v1/mint/quote/bolt11", strings.NewReader(string(jsonRequestBody)))
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Errorf("Expected status code 200, got %d", w.Code)
+	}
+	var postMintQuoteResponse cashu.PostMintQuoteBolt11Response
+	err = json.Unmarshal(w.Body.Bytes(), &postMintQuoteResponse)
+
+	if err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+	}
+
+	referenceKeyset := mint.ActiveKeysets[cashu.Sat.String()][1]
+
+	// ask for minting
+	p2pkBlindedMessages, p2pkMintingSecrets, P2PKMintingSecretKeys, err := CreateHTLCBlindedMessages(1000, referenceKeyset, correctPreimage, 1, []*secp256k1.PublicKey{lockingPrivKey.PubKey()}, nil, 0, cashu.SigInputs)
+
+	if err != nil {
+		t.Fatalf("could not createBlind message: %v", err)
+	}
+
+	mintRequest := cashu.PostMintBolt11Request{
+		Quote:   postMintQuoteResponse.Quote,
+		Outputs: p2pkBlindedMessages,
+	}
+
+	jsonRequestBody, _ = json.Marshal(mintRequest)
+
+	var aliceBlindSigs []cashu.BlindSignature
+
+	req = httptest.NewRequest("POST", "/v1/mint/bolt11", strings.NewReader(string(jsonRequestBody)))
+
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	var postMintResponse cashu.PostMintBolt11Response
+
+	if w.Code != 200 {
+		t.Fatalf("Expected status code 200, got %d", w.Code)
+	}
+
+	err = json.Unmarshal(w.Body.Bytes(), &postMintResponse)
+
+	if err != nil {
+		t.Fatalf("Error unmarshalling response: %v", err)
+	}
+
+	aliceBlindSigs = append(aliceBlindSigs, postMintResponse.Signatures...)
+
+	// SWAP HTLC TOKEN with other HTLC TOKENS
+	swapProofs, err := GenerateProofsHTLC(postMintResponse.Signatures, correctPreimage, mint.ActiveKeysets, p2pkMintingSecrets, P2PKMintingSecretKeys, []*secp256k1.PrivateKey{lockingPrivKey})
+
+	if err != nil {
+		t.Fatalf("Error generating proofs: %v", err)
+	}
+
+
+	swapBlindedMessagesP2PK, swapSecretsP2PK, swapSecretKeyP2PK, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 1, []*secp256k1.PublicKey{lockingPrivKey.PubKey()}, nil, 0, cashu.SigInputs)
+
+	if err != nil {
+		t.Fatalf("could not createBlind message: %v", err)
+	}
+
+	swapRequest := cashu.PostSwapRequest{
+		Inputs:  swapProofs,
+		Outputs: swapBlindedMessagesP2PK,
+	}
+
+	jsonRequestBody, _ = json.Marshal(swapRequest)
+
+	req = httptest.NewRequest("POST", "/v1/swap", strings.NewReader(string(jsonRequestBody)))
+
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	var postSwapResponse cashu.PostSwapResponse
+
+	if w.Code != 200 {
+		t.Fatalf("Expected status code 200, got %d", w.Code)
+	}
+
+	err = json.Unmarshal(w.Body.Bytes(), &postSwapResponse)
+
+	if err != nil {
+		t.Fatalf("Error unmarshalling response: %v", err)
+	}
+
+	// TRY SWAPING with WRONG SIGNATURES
+	swapProofsWrongSigs, err := GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage,  mint.ActiveKeysets, swapSecretsP2PK, swapSecretKeyP2PK, []*secp256k1.PrivateKey{wrongPrivKey})
+
+	if err != nil {
+		t.Fatalf("Error generating proofs: %v", err)
+	}
+
+	swapBlindedMessagesP2PKWrongSigs, _, _, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 1, []*secp256k1.PublicKey{lockingPrivKey.PubKey()}, nil, 0, cashu.SigInputs)
+
+	if err != nil {
+		t.Fatalf("could not createBlind message: %v", err)
+	}
+
+	swapRequestTwo := cashu.PostSwapRequest{
+		Inputs:  swapProofsWrongSigs,
+		Outputs: swapBlindedMessagesP2PKWrongSigs,
+	}
+
+	jsonRequestBody, _ = json.Marshal(swapRequestTwo)
+
+	req = httptest.NewRequest("POST", "/v1/swap", strings.NewReader(string(jsonRequestBody)))
+
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != 403 {
+		t.Fatalf("Expected status code 403, got %d", w.Code)
+	}
+
+	if w.Body.String() != `"No valid signatures"` {
+		t.Fatalf("Expected response No valid signatures, got %s", w.Body.String())
+	}
+
+}
+
+func CreateHTLCBlindedMessages(amount uint64, keyset cashu.Keyset, preimage string, nSigs int, pubkeys []*secp256k1.PublicKey, refundPubkey []*secp256k1.PublicKey, locktime int, sigflag cashu.SigFlag) ([]cashu.BlindedMessage, []string, []*secp256k1.PrivateKey, error) {
+	splitAmounts := cashu.AmountSplit(amount)
+	splitLen := len(splitAmounts)
+
+	blindedMessages := make([]cashu.BlindedMessage, splitLen)
+	secrets := make([]string, splitLen)
+	rs := make([]*secp256k1.PrivateKey, splitLen)
+
+	for i, amt := range splitAmounts {
+		spendCond, err := makeHTLCSpendCondition(preimage, nSigs, pubkeys, refundPubkey, locktime, sigflag)
+
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("MakeP2PKSpendCondition: %w", err)
+		}
+
+		jsonSpend, err := spendCond.String()
+
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("json.Marshal(spendCond): %w", err)
+		}
+
+		// generate new private key r
+		r, err := secp256k1.GeneratePrivateKey()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		var B_ *secp256k1.PublicKey
+		var secret string = jsonSpend
+		// generate random secret until it finds valid point
+		for {
+			B_, r, err = crypto.BlindMessage(secret, r)
+			if err == nil {
+				break
+			}
+		}
+
+		blindedMessage := newBlindedMessage(keyset.Id, amt, B_)
+		blindedMessages[i] = blindedMessage
+		secrets[i] = secret
+		rs[i] = r
+	}
+
+	return blindedMessages, secrets, rs, nil
+}
+
+func makeHTLCSpendCondition(preimage string, nSigs int, pubkeys []*secp256k1.PublicKey, refundPubkey []*secp256k1.PublicKey, locktime int, sigflag cashu.SigFlag) (cashu.SpendCondition, error) {
+
+    bytesPreimage, err := hex.DecodeString(preimage)
+    if err != nil {
+        return cashu.SpendCondition{}, err
+    }
+
+    parsedPreimage := sha256.Sum256(bytesPreimage)
+
+	var spendCondition cashu.SpendCondition
+	spendCondition.Type = cashu.HTLC
+	spendCondition.Data.Data = hex.EncodeToString(parsedPreimage[:])
+	spendCondition.Data.Tags.Pubkeys = pubkeys
+	spendCondition.Data.Tags.NSigs = nSigs
+	spendCondition.Data.Tags.Locktime = locktime
+	spendCondition.Data.Tags.Sigflag = sigflag
+	spendCondition.Data.Tags.Refund = refundPubkey
+
+	// generate random Nonce
+	nonce := make([]byte, 32)  // create a slice with length 16 for the nonce
+    _, err = rand.Read(nonce) // read random bytes into the nonce slice
+	if err != nil {
+		return spendCondition, err
+	}
+	spendCondition.Data.Nonce = hex.EncodeToString(nonce)
+
+	return spendCondition, nil
+}
+
+func GenerateProofsHTLC(signatures []cashu.BlindSignature, preimage string, keysets map[string]mint.KeysetMap, secrets []string, secretsKey []*secp256k1.PrivateKey, privkeys []*secp256k1.PrivateKey) ([]cashu.Proof, error) {
+	// try to swap tokens
+	var proofs []cashu.Proof
+	// unblid the signatures and make proofs
+	for i, output := range signatures {
+
+		parsedBlindFactor, err := hex.DecodeString(output.C_)
+		if err != nil {
+			return nil, fmt.Errorf("Error decoding hex: %w", err)
+		}
+		blindedFactor, err := secp256k1.ParsePubKey(parsedBlindFactor)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing pubkey: %w", err)
+		}
+
+		mintPublicKey, err := secp256k1.ParsePubKey(keysets[cashu.Sat.String()][output.Amount].PrivKey.PubKey().SerializeCompressed())
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing pubkey: %w", err)
+		}
+
+		C := crypto.UnblindSignature(blindedFactor, secretsKey[i], mintPublicKey)
+
+		hexC := hex.EncodeToString(C.SerializeCompressed())
+
+		proof := cashu.Proof{Id: output.Id, Amount: output.Amount, C: hexC, Secret: secrets[i]}
+
+		for _, privkey := range privkeys {
+			err = proof.Sign(privkey)
+			if err != nil {
+				return nil, fmt.Errorf("Error signing proof: %w", err)
+			}
+			err = proof.AddPreimage(preimage)
+			if err != nil {
+				return nil, fmt.Errorf("Error signing proof: %w", err)
+			}
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("Error signing proof: %w", err)
+		}
+
+		proofs = append(proofs, proof)
+	}
+
+	return proofs, nil
+}
+
+func TestHTLCMultisigSigning(t *testing.T) {
+	const posgrespassword = "password"
+	const postgresuser = "user"
+	ctx := context.Background()
+
+	postgresContainer, err := postgres.RunContainer(ctx,
+		testcontainers.WithImage("postgres:16.2"),
+		postgres.WithDatabase("postgres"),
+		postgres.WithUsername(postgresuser),
+		postgres.WithPassword(posgrespassword),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(5*time.Second)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	connUri, err := postgresContainer.ConnectionString(ctx)
+
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to get connection string: %w", err))
+	}
+
+	os.Setenv(database.DATABASE_URL_ENV, connUri)
+	os.Setenv(MINT_PRIVATE_KEY_ENV, MintPrivateKey)
+	os.Setenv(mint.MINT_LIGHTNING_BACKEND_ENV, "FakeWallet")
+	os.Setenv(mint.NETWORK_ENV, "regtest")
+
+	ctx = context.WithValue(ctx, mint.NETWORK_ENV, os.Getenv(mint.NETWORK_ENV))
+	ctx = context.WithValue(ctx, mint.MINT_LIGHTNING_BACKEND_ENV, os.Getenv(mint.MINT_LIGHTNING_BACKEND_ENV))
+	ctx = context.WithValue(ctx, database.DATABASE_URL_ENV, os.Getenv(database.DATABASE_URL_ENV))
+	ctx = context.WithValue(ctx, mint.NETWORK_ENV, os.Getenv(mint.NETWORK_ENV))
+
+	router, mint := SetupRoutingForTesting(ctx)
+
+	lockingPrivKeyOne := secp256k1.PrivKeyFromBytes([]byte{0x01, 0x02, 0x03, 0x04})
+
+	lockingPrivKeyTwo := secp256k1.PrivKeyFromBytes([]byte{0x01, 0x02, 0x03, 0x05})
+
+	wrongPrivKey := secp256k1.PrivKeyFromBytes([]byte{0x01, 0x02, 0x03, 0x08})
+
+	if err != nil {
+		t.Fatalf("could not parse locking pubkey: %v", err)
+	}
+
+	// MINTING TESTING STARTS
+	// request mint quote of 1000 sats
+	w := httptest.NewRecorder()
+
+	mintQuoteRequest := cashu.PostMintQuoteBolt11Request{
+		Amount: 1000,
+		Unit:   cashu.Sat.String(),
+	}
+	jsonRequestBody, _ := json.Marshal(mintQuoteRequest)
+
+	req := httptest.NewRequest("POST", "/v1/mint/quote/bolt11", strings.NewReader(string(jsonRequestBody)))
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Errorf("Expected status code 200, got %d", w.Code)
+	}
+	var postMintQuoteResponse cashu.PostMintQuoteBolt11Response
+	err = json.Unmarshal(w.Body.Bytes(), &postMintQuoteResponse)
+
+	if err != nil {
+		t.Errorf("Error unmarshalling response: %v", err)
+	}
+
+	referenceKeyset := mint.ActiveKeysets[cashu.Sat.String()][1]
+
+	// ask for minting
+	// Create multisig token for 2 pubkeys
+	p2pkBlindedMessages, p2pkMintingSecrets, P2PKMintingSecretKeys, err := CreateHTLCBlindedMessages(1000, referenceKeyset, correctPreimage, 2, []*secp256k1.PublicKey{lockingPrivKeyTwo.PubKey()}, nil, 0, cashu.SigInputs)
+
+	if err != nil {
+		t.Fatalf("could not createBlind message: %v", err)
+	}
+
+	mintRequest := cashu.PostMintBolt11Request{
+		Quote:   postMintQuoteResponse.Quote,
+		Outputs: p2pkBlindedMessages,
+	}
+
+	jsonRequestBody, _ = json.Marshal(mintRequest)
+
+	var aliceBlindSigs []cashu.BlindSignature
+
+	req = httptest.NewRequest("POST", "/v1/mint/bolt11", strings.NewReader(string(jsonRequestBody)))
+
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	var postMintResponse cashu.PostMintBolt11Response
+
+	if w.Code != 200 {
+		t.Fatalf("Expected status code 200, got %d", w.Code)
+	}
+
+	err = json.Unmarshal(w.Body.Bytes(), &postMintResponse)
+
+	if err != nil {
+		t.Fatalf("Error unmarshalling response: %v", err)
+	}
+
+	aliceBlindSigs = append(aliceBlindSigs, postMintResponse.Signatures...)
+
+	// SWAP P2PK TOKEN with other P2PK TOKENS
+	// sign multisig with correct privkeys
+	swapProofs, err := GenerateProofsHTLC(postMintResponse.Signatures,correctPreimage, mint.ActiveKeysets, p2pkMintingSecrets, P2PKMintingSecretKeys, []*secp256k1.PrivateKey{lockingPrivKeyOne, lockingPrivKeyTwo})
+
+	if err != nil {
+		t.Fatalf("Error generating proofs: %v", err)
+	}
+
+	refundPrivKey := secp256k1.PrivKeyFromBytes([]byte{0x01, 0x02, 0x03, 0x06})
+
+	swapBlindedMessagesP2PK, swapSecretsP2PK, swapSecretKeyP2PK, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 2, []*secp256k1.PublicKey{lockingPrivKeyTwo.PubKey()}, []*secp256k1.PublicKey{refundPrivKey.PubKey()}, 100, cashu.SigInputs)
+
+	if err != nil {
+		t.Fatalf("could not createBlind message: %v", err)
+	}
+
+	swapRequest := cashu.PostSwapRequest{
+		Inputs:  swapProofs,
+		Outputs: swapBlindedMessagesP2PK,
+	}
+
+	jsonRequestBody, _ = json.Marshal(swapRequest)
+
+	req = httptest.NewRequest("POST", "/v1/swap", strings.NewReader(string(jsonRequestBody)))
+
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	var postSwapResponse cashu.PostSwapResponse
+
+	if w.Code != 200 {
+		t.Fatalf("Expected status code 200, got %d", w.Code)
+	}
+
+	err = json.Unmarshal(w.Body.Bytes(), &postSwapResponse)
+
+	if err != nil {
+		t.Fatalf("Error unmarshalling response: %v", err)
+	}
+
+	// // TRY SWAPING with Timelock passed
+	swapProofsTimelockNotExpiredWrongSig, err := GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsP2PK, swapSecretKeyP2PK, []*secp256k1.PrivateKey{lockingPrivKeyTwo, wrongPrivKey})
+
+	if err != nil {
+		t.Fatalf("Error generating proofs: %v", err)
+	}
+
+	swapBlindedMessagesP2PKWrongSigs, _, _, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 2, []*secp256k1.PublicKey{lockingPrivKeyTwo.PubKey()}, []*secp256k1.PublicKey{refundPrivKey.PubKey()}, 100, cashu.SigInputs)
+
+	if err != nil {
+		t.Fatalf("could not createBlind message: %v", err)
+	}
+
+	swapRequestTwo := cashu.PostSwapRequest{
+		Inputs:  swapProofsTimelockNotExpiredWrongSig,
+		Outputs: swapBlindedMessagesP2PKWrongSigs,
+	}
+
+	jsonRequestBody, _ = json.Marshal(swapRequestTwo)
+
+	req = httptest.NewRequest("POST", "/v1/swap", strings.NewReader(string(jsonRequestBody)))
+
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != 403 {
+		t.Fatalf("Expected status code 403, got %d", w.Code)
+	}
+
+	if w.Body.String() != `"Locktime has passed and no refund key was found"` {
+		t.Fatalf("Expected response No valid signatures, got %s", w.Body.String())
+	}
+
+	// TRY SWAPPING with refund key
+	swapProofsRefund, err := GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsP2PK, swapSecretKeyP2PK, []*secp256k1.PrivateKey{lockingPrivKeyTwo, refundPrivKey})
+
+	currentPlus15 := time.Now().Add(15 * time.Minute).Unix()
+
+	// generate new blind signatures with timelock over 15 minutes of current time
+	swapBlindedMessagesP2PKWrongSigsOverlock, swapSecretsP2PK, swapSecretKeyP2PK, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 2, []*secp256k1.PublicKey{lockingPrivKeyTwo.PubKey()}, []*secp256k1.PublicKey{refundPrivKey.PubKey()}, int(currentPlus15), cashu.SigInputs)
+
+	if err != nil {
+		t.Fatalf("Error generating proofs: %v", err)
+	}
+	swapRequestRefund := cashu.PostSwapRequest{
+		Inputs:  swapProofsRefund,
+		Outputs: swapBlindedMessagesP2PKWrongSigsOverlock,
+	}
+
+	jsonRequestBody, _ = json.Marshal(swapRequestRefund)
+
+	req = httptest.NewRequest("POST", "/v1/swap", strings.NewReader(string(jsonRequestBody)))
+
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// var postSwapResponse cashu.PostSwapResponse
+
+	if w.Code != 200 {
+		t.Fatalf("Expected status code 200, got %d", w.Code)
+	}
+
+	err = json.Unmarshal(w.Body.Bytes(), &postSwapResponse)
+
+	if err != nil {
+		t.Fatalf("Error unmarshalling response: %v", err)
+	}
+
+	// try swapping with wrong refund key and timelock not yet expired
+
+	swapProofsTimelockNotExpiredWrongSig, err = GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsP2PK, swapSecretKeyP2PK, []*secp256k1.PrivateKey{lockingPrivKeyTwo, wrongPrivKey})
+
+	if err != nil {
+		t.Fatalf("Error generating proofs: %v", err)
+	}
+
+	swapBlindedMessagesP2PKWrongSigs, _, _, err = CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 2, []*secp256k1.PublicKey{lockingPrivKeyTwo.PubKey()}, []*secp256k1.PublicKey{refundPrivKey.PubKey()}, 100, cashu.SigInputs)
+
+	if err != nil {
+		t.Fatalf("could not createBlind message: %v", err)
+	}
+
+	swapRequestTwo = cashu.PostSwapRequest{
+		Inputs:  swapProofsTimelockNotExpiredWrongSig,
+		Outputs: swapBlindedMessagesP2PKWrongSigs,
+	}
+
+	jsonRequestBody, _ = json.Marshal(swapRequestTwo)
+
+	req = httptest.NewRequest("POST", "/v1/swap", strings.NewReader(string(jsonRequestBody)))
+
+	w = httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != 403 {
+		t.Fatalf("Expected status code 403, got %d", w.Code)
+	}
+
+	if w.Body.String() != `"Not enough signatures"` {
+		t.Fatalf("Expected response No valid signatures, got %s", w.Body.String())
+	}
+
+}

--- a/cmd/nutmix/htlc_route_test.go
+++ b/cmd/nutmix/htlc_route_test.go
@@ -98,7 +98,7 @@ func TestRoutesHTLCSwapMelt(t *testing.T) {
 	referenceKeyset := mint.ActiveKeysets[cashu.Sat.String()][1]
 
 	// ask for minting
-	p2pkBlindedMessages, p2pkMintingSecrets, P2PKMintingSecretKeys, err := CreateHTLCBlindedMessages(1000, referenceKeyset, correctPreimage, 1, []*secp256k1.PublicKey{lockingPrivKey.PubKey()}, nil, 0, cashu.SigInputs)
+	htlcBlindedMessages, htlcMintingSecrets, HTLCMintingSecretKeys, err := CreateHTLCBlindedMessages(1000, referenceKeyset, correctPreimage, 1, []*secp256k1.PublicKey{lockingPrivKey.PubKey()}, nil, 0, cashu.SigInputs)
 
 	if err != nil {
 		t.Fatalf("could not createBlind message: %v", err)
@@ -106,7 +106,7 @@ func TestRoutesHTLCSwapMelt(t *testing.T) {
 
 	mintRequest := cashu.PostMintBolt11Request{
 		Quote:   postMintQuoteResponse.Quote,
-		Outputs: p2pkBlindedMessages,
+		Outputs: htlcBlindedMessages,
 	}
 
 	jsonRequestBody, _ = json.Marshal(mintRequest)
@@ -134,13 +134,13 @@ func TestRoutesHTLCSwapMelt(t *testing.T) {
 	aliceBlindSigs = append(aliceBlindSigs, postMintResponse.Signatures...)
 
 	// SWAP HTLC TOKEN with other HTLC TOKENS
-	swapProofs, err := GenerateProofsHTLC(postMintResponse.Signatures, correctPreimage, mint.ActiveKeysets, p2pkMintingSecrets, P2PKMintingSecretKeys, []*secp256k1.PrivateKey{lockingPrivKey})
+	swapProofs, err := GenerateProofsHTLC(postMintResponse.Signatures, correctPreimage, mint.ActiveKeysets, htlcMintingSecrets, HTLCMintingSecretKeys, []*secp256k1.PrivateKey{lockingPrivKey})
 
 	if err != nil {
 		t.Fatalf("Error generating proofs: %v", err)
 	}
 
-	swapBlindedMessagesP2PK, swapSecretsP2PK, swapSecretKeyP2PK, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 1, []*secp256k1.PublicKey{lockingPrivKey.PubKey()}, nil, 0, cashu.SigInputs)
+	swapBlindedMessagesHTLC, swapSecretsHTLC, swapSecretKeyHTLC, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 1, []*secp256k1.PublicKey{lockingPrivKey.PubKey()}, nil, 0, cashu.SigInputs)
 
 	if err != nil {
 		t.Fatalf("could not createBlind message: %v", err)
@@ -148,7 +148,7 @@ func TestRoutesHTLCSwapMelt(t *testing.T) {
 
 	swapRequest := cashu.PostSwapRequest{
 		Inputs:  swapProofs,
-		Outputs: swapBlindedMessagesP2PK,
+		Outputs: swapBlindedMessagesHTLC,
 	}
 
 	jsonRequestBody, _ = json.Marshal(swapRequest)
@@ -172,13 +172,13 @@ func TestRoutesHTLCSwapMelt(t *testing.T) {
 	}
 
 	// TRY SWAPING with WRONG SIGNATURES
-	swapProofsWrongSigs, err := GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsP2PK, swapSecretKeyP2PK, []*secp256k1.PrivateKey{wrongPrivKey})
+	swapProofsWrongSigs, err := GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsHTLC, swapSecretKeyHTLC, []*secp256k1.PrivateKey{wrongPrivKey})
 
 	if err != nil {
 		t.Fatalf("Error generating proofs: %v", err)
 	}
 
-	swapBlindedMessagesP2PKWrongSigs, _, _, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 1, []*secp256k1.PublicKey{lockingPrivKey.PubKey()}, nil, 0, cashu.SigInputs)
+	swapBlindedMessagesHTLCWrongSigs, _, _, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 1, []*secp256k1.PublicKey{lockingPrivKey.PubKey()}, nil, 0, cashu.SigInputs)
 
 	if err != nil {
 		t.Fatalf("could not createBlind message: %v", err)
@@ -186,7 +186,7 @@ func TestRoutesHTLCSwapMelt(t *testing.T) {
 
 	swapRequestTwo := cashu.PostSwapRequest{
 		Inputs:  swapProofsWrongSigs,
-		Outputs: swapBlindedMessagesP2PKWrongSigs,
+		Outputs: swapBlindedMessagesHTLCWrongSigs,
 	}
 
 	jsonRequestBody, _ = json.Marshal(swapRequestTwo)
@@ -206,13 +206,13 @@ func TestRoutesHTLCSwapMelt(t *testing.T) {
 	}
 
 	// TRY SWAPING with WRONG Preimage
-	swapProofsWrongSigs, err = GenerateProofsHTLC(postSwapResponse.Signatures, incorrectPreimage, mint.ActiveKeysets, swapSecretsP2PK, swapSecretKeyP2PK, []*secp256k1.PrivateKey{wrongPrivKey})
+	swapProofsWrongSigs, err = GenerateProofsHTLC(postSwapResponse.Signatures, incorrectPreimage, mint.ActiveKeysets, swapSecretsHTLC, swapSecretKeyHTLC, []*secp256k1.PrivateKey{wrongPrivKey})
 
 	if err != nil {
 		t.Fatalf("Error generating proofs: %v", err)
 	}
 
-	swapBlindedMessagesP2PKWrongSigs, _, _, err = CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 1, []*secp256k1.PublicKey{lockingPrivKey.PubKey()}, nil, 0, cashu.SigInputs)
+	swapBlindedMessagesHTLCWrongSigs, _, _, err = CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 1, []*secp256k1.PublicKey{lockingPrivKey.PubKey()}, nil, 0, cashu.SigInputs)
 
 	if err != nil {
 		t.Fatalf("could not createBlind message: %v", err)
@@ -220,7 +220,7 @@ func TestRoutesHTLCSwapMelt(t *testing.T) {
 
 	swapRequestTwo = cashu.PostSwapRequest{
 		Inputs:  swapProofsWrongSigs,
-		Outputs: swapBlindedMessagesP2PKWrongSigs,
+		Outputs: swapBlindedMessagesHTLCWrongSigs,
 	}
 
 	jsonRequestBody, _ = json.Marshal(swapRequestTwo)
@@ -253,7 +253,7 @@ func CreateHTLCBlindedMessages(amount uint64, keyset cashu.Keyset, preimage stri
 		spendCond, err := makeHTLCSpendCondition(preimage, nSigs, pubkeys, refundPubkey, locktime, sigflag)
 
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("MakeP2PKSpendCondition: %w", err)
+			return nil, nil, nil, fmt.Errorf("MakeHTLCSpendCondition: %w", err)
 		}
 
 		jsonSpend, err := spendCond.String()
@@ -438,7 +438,7 @@ func TestHTLCMultisigSigning(t *testing.T) {
 
 	// ask for minting
 	// Create multisig token for 2 pubkeys
-	p2pkBlindedMessages, p2pkMintingSecrets, P2PKMintingSecretKeys, err := CreateHTLCBlindedMessages(1000, referenceKeyset, correctPreimage, 2, []*secp256k1.PublicKey{lockingPrivKeyOne.PubKey(), lockingPrivKeyTwo.PubKey()}, nil, 0, cashu.SigInputs)
+	htlcBlindedMessages, htlcMintingSecrets, HTLCMintingSecretKeys, err := CreateHTLCBlindedMessages(1000, referenceKeyset, correctPreimage, 2, []*secp256k1.PublicKey{lockingPrivKeyOne.PubKey(), lockingPrivKeyTwo.PubKey()}, nil, 0, cashu.SigInputs)
 
 	if err != nil {
 		t.Fatalf("could not createBlind message: %v", err)
@@ -446,7 +446,7 @@ func TestHTLCMultisigSigning(t *testing.T) {
 
 	mintRequest := cashu.PostMintBolt11Request{
 		Quote:   postMintQuoteResponse.Quote,
-		Outputs: p2pkBlindedMessages,
+		Outputs: htlcBlindedMessages,
 	}
 
 	jsonRequestBody, _ = json.Marshal(mintRequest)
@@ -473,9 +473,9 @@ func TestHTLCMultisigSigning(t *testing.T) {
 
 	aliceBlindSigs = append(aliceBlindSigs, postMintResponse.Signatures...)
 
-	// SWAP P2PK TOKEN with other P2PK TOKENS
+	// SWAP HTLC TOKEN with other HTLC TOKENS
 	// sign multisig with correct privkeys
-	swapProofs, err := GenerateProofsHTLC(postMintResponse.Signatures, correctPreimage, mint.ActiveKeysets, p2pkMintingSecrets, P2PKMintingSecretKeys, []*secp256k1.PrivateKey{lockingPrivKeyOne, lockingPrivKeyTwo})
+	swapProofs, err := GenerateProofsHTLC(postMintResponse.Signatures, correctPreimage, mint.ActiveKeysets, htlcMintingSecrets, HTLCMintingSecretKeys, []*secp256k1.PrivateKey{lockingPrivKeyOne, lockingPrivKeyTwo})
 
 	if err != nil {
 		t.Fatalf("Error generating proofs: %v", err)
@@ -483,7 +483,7 @@ func TestHTLCMultisigSigning(t *testing.T) {
 
 	refundPrivKey := secp256k1.PrivKeyFromBytes([]byte{0x01, 0x02, 0x03, 0x06})
 
-	swapBlindedMessagesP2PK, swapSecretsP2PK, swapSecretKeyP2PK, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 2, []*secp256k1.PublicKey{lockingPrivKeyTwo.PubKey(), lockingPrivKeyOne.PubKey(), lockingPrivKeyTwo.PubKey()}, []*secp256k1.PublicKey{refundPrivKey.PubKey()}, 100, cashu.SigInputs)
+	swapBlindedMessagesHTLC, swapSecretsHTLC, swapSecretKeyHTLC, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 2, []*secp256k1.PublicKey{lockingPrivKeyTwo.PubKey(), lockingPrivKeyOne.PubKey(), lockingPrivKeyTwo.PubKey()}, []*secp256k1.PublicKey{refundPrivKey.PubKey()}, 100, cashu.SigInputs)
 
 	if err != nil {
 		t.Fatalf("could not createBlind message: %v", err)
@@ -491,7 +491,7 @@ func TestHTLCMultisigSigning(t *testing.T) {
 
 	swapRequest := cashu.PostSwapRequest{
 		Inputs:  swapProofs,
-		Outputs: swapBlindedMessagesP2PK,
+		Outputs: swapBlindedMessagesHTLC,
 	}
 
 	jsonRequestBody, _ = json.Marshal(swapRequest)
@@ -515,7 +515,7 @@ func TestHTLCMultisigSigning(t *testing.T) {
 	}
 
 	// // TRY SWAPING with Timelock passed
-	swapProofsTimelockNotExpiredWrongSig, err := GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsP2PK, swapSecretKeyP2PK, []*secp256k1.PrivateKey{lockingPrivKeyTwo, wrongPrivKey})
+	swapProofsTimelockNotExpiredWrongSig, err := GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsHTLC, swapSecretKeyHTLC, []*secp256k1.PrivateKey{lockingPrivKeyTwo, wrongPrivKey})
 
 	if err != nil {
 		t.Fatalf("Error generating proofs: %v", err)
@@ -549,19 +549,19 @@ func TestHTLCMultisigSigning(t *testing.T) {
 	}
 
 	// TRY SWAPPING with refund key
-	swapProofsRefund, err := GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsP2PK, swapSecretKeyP2PK, []*secp256k1.PrivateKey{lockingPrivKeyTwo, refundPrivKey})
+	swapProofsRefund, err := GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsHTLC, swapSecretKeyHTLC, []*secp256k1.PrivateKey{lockingPrivKeyTwo, refundPrivKey})
 
 	currentPlus15 := time.Now().Add(15 * time.Minute).Unix()
 
 	// generate new blind signatures with timelock over 15 minutes of current time
-	swapBlindedMessagesP2PKWrongSigsOverlock, swapSecretsP2PK, swapSecretKeyP2PK, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 2, []*secp256k1.PublicKey{lockingPrivKeyOne.PubKey(), lockingPrivKeyTwo.PubKey()}, []*secp256k1.PublicKey{refundPrivKey.PubKey()}, int(currentPlus15), cashu.SigInputs)
+	swapBlindedMessagesHTLCWrongSigsOverlock, swapSecretsHTLC, swapSecretKeyHTLC, err := CreateHTLCBlindedMessages(1000, mint.ActiveKeysets[cashu.Sat.String()][1], correctPreimage, 2, []*secp256k1.PublicKey{lockingPrivKeyOne.PubKey(), lockingPrivKeyTwo.PubKey()}, []*secp256k1.PublicKey{refundPrivKey.PubKey()}, int(currentPlus15), cashu.SigInputs)
 
 	if err != nil {
 		t.Fatalf("Error generating proofs: %v", err)
 	}
 	swapRequestRefund := cashu.PostSwapRequest{
 		Inputs:  swapProofsRefund,
-		Outputs: swapBlindedMessagesP2PKWrongSigsOverlock,
+		Outputs: swapBlindedMessagesHTLCWrongSigsOverlock,
 	}
 
 	jsonRequestBody, _ = json.Marshal(swapRequestRefund)
@@ -584,7 +584,7 @@ func TestHTLCMultisigSigning(t *testing.T) {
 
 	// try swapping with wrong refund key and timelock not yet expired
 
-	swapProofsTimelockNotExpiredWrongSig, err = GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsP2PK, swapSecretKeyP2PK, []*secp256k1.PrivateKey{lockingPrivKeyTwo, wrongPrivKey})
+	swapProofsTimelockNotExpiredWrongSig, err = GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsHTLC, swapSecretKeyHTLC, []*secp256k1.PrivateKey{lockingPrivKeyTwo, wrongPrivKey})
 
 	if err != nil {
 		t.Fatalf("Error generating proofs: %v", err)
@@ -618,7 +618,7 @@ func TestHTLCMultisigSigning(t *testing.T) {
 	}
 
 	// Try swapping with not enough signatures
-	swapProofsTimelockNotExpiredWrongSig, err = GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsP2PK, swapSecretKeyP2PK, []*secp256k1.PrivateKey{lockingPrivKeyTwo})
+	swapProofsTimelockNotExpiredWrongSig, err = GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsHTLC, swapSecretKeyHTLC, []*secp256k1.PrivateKey{lockingPrivKeyTwo})
 
 	if err != nil {
 		t.Fatalf("Error generating proofs: %v", err)
@@ -652,7 +652,7 @@ func TestHTLCMultisigSigning(t *testing.T) {
 	}
 
 	// Try swapping with correct signatures but wrong preimage
-	swapProofsTimelockNotExpiredWrongSig, err = GenerateProofsHTLC(postSwapResponse.Signatures, incorrectPreimage, mint.ActiveKeysets, swapSecretsP2PK, swapSecretKeyP2PK, []*secp256k1.PrivateKey{lockingPrivKeyOne, lockingPrivKeyTwo})
+	swapProofsTimelockNotExpiredWrongSig, err = GenerateProofsHTLC(postSwapResponse.Signatures, incorrectPreimage, mint.ActiveKeysets, swapSecretsHTLC, swapSecretKeyHTLC, []*secp256k1.PrivateKey{lockingPrivKeyOne, lockingPrivKeyTwo})
 
 	if err != nil {
 		t.Fatalf("Error generating proofs: %v", err)
@@ -686,7 +686,7 @@ func TestHTLCMultisigSigning(t *testing.T) {
 	}
 
 	// Try swapping with correct signatures and correct preimage
-	swapProofsTimelockNotExpiredWrongSig, err = GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsP2PK, swapSecretKeyP2PK, []*secp256k1.PrivateKey{lockingPrivKeyOne, lockingPrivKeyTwo})
+	swapProofsTimelockNotExpiredWrongSig, err = GenerateProofsHTLC(postSwapResponse.Signatures, correctPreimage, mint.ActiveKeysets, swapSecretsHTLC, swapSecretKeyHTLC, []*secp256k1.PrivateKey{lockingPrivKeyOne, lockingPrivKeyTwo})
 
 	if err != nil {
 		t.Fatalf("Error generating proofs: %v", err)

--- a/cmd/nutmix/main_test.go
+++ b/cmd/nutmix/main_test.go
@@ -746,7 +746,7 @@ func TestMintBolt11LndLigthning(t *testing.T) {
 		t.Fatalf("Error setting up lightning network enviroment: %+v", err)
 	}
 
-    LightningBolt11Test(t, ctx, bobLnd)
+	LightningBolt11Test(t, ctx, bobLnd)
 
 	// Clean up the container
 	defer func() {
@@ -802,7 +802,7 @@ func TestMintBolt11LNBITSLigthning(t *testing.T) {
 		t.Fatalf("Error setting up lightning network enviroment: %+v", err)
 	}
 
-    LightningBolt11Test(t, ctx, bobLnd)
+	LightningBolt11Test(t, ctx, bobLnd)
 
 	// Clean up the container
 	defer func() {
@@ -868,7 +868,7 @@ func LightningBolt11Test(t *testing.T, ctx context.Context, bobLnd testcontainer
 	}
 
 	var postMintQuoteResponse cashu.PostMintQuoteBolt11Response
-    err := json.Unmarshal(w.Body.Bytes(), &postMintQuoteResponse)
+	err := json.Unmarshal(w.Body.Bytes(), &postMintQuoteResponse)
 
 	if err != nil {
 		t.Errorf("Error unmarshalling response: %v", err)

--- a/cmd/nutmix/p2pk_route_test.go
+++ b/cmd/nutmix/p2pk_route_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-func TestRoutesSwapMelt(t *testing.T) {
+func TestRoutesP2PKSwapMelt(t *testing.T) {
 	const posgrespassword = "password"
 	const postgresuser = "user"
 	ctx := context.Background()
@@ -252,7 +252,7 @@ func CreateP2PKBlindedMessages(amount uint64, keyset cashu.Keyset, pubkey *secp2
 func makeP2PKSpendCondition(pubkey *secp256k1.PublicKey, nSigs int, pubkeys []*secp256k1.PublicKey, refundPubkey []*secp256k1.PublicKey, locktime int, sigflag cashu.SigFlag) (cashu.SpendCondition, error) {
 	var spendCondition cashu.SpendCondition
 	spendCondition.Type = cashu.P2PK
-	spendCondition.Data.Data = pubkey
+	spendCondition.Data.Data = hex.EncodeToString(pubkey.SerializeCompressed())
 	spendCondition.Data.Tags.Pubkeys = pubkeys
 	spendCondition.Data.Tags.NSigs = nSigs
 	spendCondition.Data.Tags.Locktime = locktime
@@ -313,7 +313,7 @@ func GenerateProofsP2PK(signatures []cashu.BlindSignature, keysets map[string]mi
 	return proofs, nil
 }
 
-func TestMultisigSigning(t *testing.T) {
+func TestP2PKMultisigSigning(t *testing.T) {
 	const posgrespassword = "password"
 	const postgresuser = "user"
 	ctx := context.Background()

--- a/internal/comms/lightning.go
+++ b/internal/comms/lightning.go
@@ -65,8 +65,8 @@ type LightningInvoiceResponse struct {
 }
 
 type LightningPaymentResponse struct {
-	Preimage     string
-	PaymentError error
+	Preimage       string
+	PaymentError   error
 	PaymentRequest string
 	Rhash          string
 }
@@ -249,7 +249,7 @@ func (l *LightingComms) PayInvoice(invoice string, feeReserve uint64) (*Lightnin
 
 		invoiceRes.PaymentRequest = lnbitsInvoice.PaymentRequest
 		invoiceRes.Rhash = lnbitsInvoice.PaymentHash
-        invoiceRes.PaymentError = errors.New("")
+		invoiceRes.PaymentError = errors.New("")
 
 		return &invoiceRes, nil
 	}
@@ -293,7 +293,7 @@ func getFeatureBits(features *lnwire.FeatureVector) []lnrpc.FeatureBit {
 }
 
 type QueryRoutesResponse struct {
-    FeeReserve uint64 `json:"fee_reserve"`
+	FeeReserve uint64 `json:"fee_reserve"`
 }
 
 func (l *LightingComms) QueryPayment(zpayInvoice *zpay32.Invoice, invoice string) (*QueryRoutesResponse, error) {
@@ -328,8 +328,7 @@ func (l *LightingComms) QueryPayment(zpayInvoice *zpay32.Invoice, invoice string
 			return nil, err
 		}
 		fee := lightning.GetAverageRouteFee(res.Routes) / 1000
-        queryResponse.FeeReserve = fee
-
+		queryResponse.FeeReserve = fee
 
 		return &queryResponse, nil
 
@@ -337,16 +336,16 @@ func (l *LightingComms) QueryPayment(zpayInvoice *zpay32.Invoice, invoice string
 		invoiceString := "/api/v1/payments/fee-reserve" + "?" + `invoice=` + invoice
 
 		err := l.LnbitsInvoiceRequest("GET", invoiceString, nil, &queryResponse)
-        queryResponse.FeeReserve = queryResponse.FeeReserve / 1000
+		queryResponse.FeeReserve = queryResponse.FeeReserve / 1000
 
 		if err != nil {
 			return nil, fmt.Errorf("json.Marshal: %w", err)
 		}
 
-        return &queryResponse, nil
+		return &queryResponse, nil
 
 	}
-    return nil, fmt.Errorf("Something happened")
+	return nil, fmt.Errorf("Something happened")
 
 }
 

--- a/internal/comms/lightning_test.go
+++ b/internal/comms/lightning_test.go
@@ -52,7 +52,7 @@ func TestSetupLightingCommsLnBits(t *testing.T) {
 		t.Fatalf("setUpLightingNetworkEnviroment %+v", err)
 	}
 
-    lightingComms, err := SetupLightingComms(ctx)
+	lightingComms, err := SetupLightingComms(ctx)
 
 	if err != nil {
 		t.Fatalf("could not setup lighting comms %+v", err)

--- a/internal/comms/util.go
+++ b/internal/comms/util.go
@@ -360,7 +360,6 @@ func SetUpLightingNetworkTestEnviroment(ctx context.Context, names string) (test
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("json.Unmarshal: %w", err)
 	}
-	fmt.Printf("Body: %+v ", response)
 
 	// get auth settings
 	authBody := struct {
@@ -410,14 +409,11 @@ func SetUpLightingNetworkTestEnviroment(ctx context.Context, names string) (test
 		return nil, nil, nil, nil, fmt.Errorf("no wallet found")
 	}
 
-	fmt.Printf("AdminKey: %+v ", responseWallet[0].AdminKey)
 	err = os.Setenv(MINT_LNBITS_KEY, responseWallet[0].AdminKey)
 	err = os.Setenv(MINT_LNBITS_ENDPOINT, "http://"+aliceLnbitsIp+":5000")
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("could not set env %w", err)
 	}
-
-	fmt.Println("Response: ", string(body))
 
 	// generate wallet
 

--- a/internal/mint/mint.go
+++ b/internal/mint/mint.go
@@ -256,7 +256,7 @@ func (m *Mint) ValidateProof(proof cashu.Proof, unit cashu.Unit, checkOutputs *b
 	}
 
 	if isProofLocked {
-		ok, err := proof.VerifyWitnessSig(spendCondition, witness, pubkeysFromProofs)
+		ok, err := proof.VerifyWitness(spendCondition, witness, pubkeysFromProofs)
 
 		if err != nil {
 			return fmt.Errorf("proof.VerifyWitnessSig(): %w", err)

--- a/internal/routes/bolt11.go
+++ b/internal/routes/bolt11.go
@@ -564,6 +564,9 @@ func v1bolt11Routes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint
 			case errors.Is(err, cashu.ErrNotEnoughSignatures):
 				c.JSON(403, cashu.ErrNotEnoughSignatures.Error())
 				return
+			case errors.Is(err, cashu.ErrLocktimePassed):
+				c.JSON(403, cashu.ErrLocktimePassed.Error())
+				return
 
 			}
 
@@ -590,7 +593,7 @@ func v1bolt11Routes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint
 				return
 			}
 
-            fmt.Printf("PaymentError: %+v ", payment)
+			fmt.Printf("PaymentError: %+v ", payment)
 
 			switch {
 			case payment.PaymentError.Error() == "invoice is already paid":

--- a/internal/routes/bolt11.go
+++ b/internal/routes/bolt11.go
@@ -596,8 +596,6 @@ func v1bolt11Routes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint
 				return
 			}
 
-			fmt.Printf("PaymentError: %+v ", payment)
-
 			switch {
 			case payment.PaymentError.Error() == "invoice is already paid":
 				c.JSON(400, "invoice is already paid")

--- a/internal/routes/bolt11.go
+++ b/internal/routes/bolt11.go
@@ -567,6 +567,9 @@ func v1bolt11Routes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint
 			case errors.Is(err, cashu.ErrLocktimePassed):
 				c.JSON(403, cashu.ErrLocktimePassed.Error())
 				return
+			case errors.Is(err, cashu.ErrInvalidPreimage):
+				c.JSON(403, cashu.ErrInvalidPreimage.Error())
+				return
 
 			}
 

--- a/internal/routes/mint.go
+++ b/internal/routes/mint.go
@@ -65,9 +65,6 @@ func v1MintRoutes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint *
 
 	v1.GET("/info", func(c *gin.Context) {
 
-		fmt.Printf("Active Swaps: %v\n", len(mint.ActiveProofs.Proofs))
-		fmt.Printf("Active Mint: %v\n", len(mint.ActiveQuotes.Quote))
-
 		seed, err := database.GetActiveSeed(pool)
 
 		var pubkey string = ""

--- a/internal/routes/mint.go
+++ b/internal/routes/mint.go
@@ -225,6 +225,9 @@ func v1MintRoutes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint *
 			case errors.Is(err, cashu.ErrNotEnoughSignatures):
 				c.JSON(403, cashu.ErrNotEnoughSignatures.Error())
 				return
+			case errors.Is(err, cashu.ErrLocktimePassed):
+				c.JSON(403, cashu.ErrLocktimePassed.Error())
+				return
 
 			}
 

--- a/internal/routes/mint.go
+++ b/internal/routes/mint.go
@@ -228,7 +228,9 @@ func v1MintRoutes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint *
 			case errors.Is(err, cashu.ErrLocktimePassed):
 				c.JSON(403, cashu.ErrLocktimePassed.Error())
 				return
-
+			case errors.Is(err, cashu.ErrInvalidPreimage):
+				c.JSON(403, cashu.ErrInvalidPreimage.Error())
+				return
 			}
 
 			c.JSON(403, "Invalid Proof")


### PR DESCRIPTION
[Nut 14](https://github.com/cashubtc/nuts/blob/main/14.md)

- Fix error where where expiry is already happened only check for refund keys
- htlc testing on routes
- treat the secret as a string and not a public key by default. Parse as needed
- individual testing on spend condition htlc

fixes #57 