### PR TITLE
check for unit before doing mint and melt

### DIFF
--- a/cmd/nutmix/info_test.go
+++ b/cmd/nutmix/info_test.go
@@ -76,8 +76,8 @@ func TestMintInfo(t *testing.T) {
 		t.Errorf("Incorrect version  %v", mintInfo.Version)
 	}
 
-    if mintInfo.Pubkey != "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798" {
+	if mintInfo.Pubkey != "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798" {
 		t.Errorf("Incorrect Pubkey  %v", mintInfo.Pubkey)
-    }
+	}
 
 }

--- a/cmd/nutmix/main_test.go
+++ b/cmd/nutmix/main_test.go
@@ -1418,5 +1418,84 @@ func LightningBolt11Test(t *testing.T, ctx context.Context, bobLnd testcontainer
 	}
 
 	// MELTING TESTING ENDS
+}
+
+func TestWrongUnitOnMeltAndMint(t *testing.T) {
+	const posgrespassword = "password"
+	const postgresuser = "user"
+	ctx := context.Background()
+
+	postgresContainer, err := postgres.RunContainer(ctx,
+		testcontainers.WithImage("postgres:16.2"),
+		postgres.WithDatabase("postgres"),
+		postgres.WithUsername(postgresuser),
+		postgres.WithPassword(posgrespassword),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(5*time.Second)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	connUri, err := postgresContainer.ConnectionString(ctx)
+
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to get connection string: %w", err))
+	}
+
+	os.Setenv("DATABASE_URL", connUri)
+	os.Setenv("MINT_PRIVATE_KEY", MintPrivateKey)
+	os.Setenv("MINT_LIGHTNING_BACKEND", "FakeWallet")
+	os.Setenv(mint.NETWORK_ENV, "regtest")
+
+	ctx = context.WithValue(ctx, mint.NETWORK_ENV, os.Getenv(mint.NETWORK_ENV))
+	ctx = context.WithValue(ctx, mint.MINT_LIGHTNING_BACKEND_ENV, os.Getenv(mint.MINT_LIGHTNING_BACKEND_ENV))
+	ctx = context.WithValue(ctx, database.DATABASE_URL_ENV, os.Getenv(database.DATABASE_URL_ENV))
+	ctx = context.WithValue(ctx, mint.NETWORK_ENV, os.Getenv(mint.NETWORK_ENV))
+
+	router, _ := SetupRoutingForTesting(ctx)
+
+	// Mint check incorrect unit
+	w := httptest.NewRecorder()
+
+	mintQuoteRequest := cashu.PostMintQuoteBolt11Request{
+		Amount: 10000,
+		Unit:   "Milsat",
+	}
+	jsonRequestBody, _ := json.Marshal(mintQuoteRequest)
+
+	req := httptest.NewRequest("POST", "/v1/mint/quote/bolt11", strings.NewReader(string(jsonRequestBody)))
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Errorf("Expected status code 200, got %d", w.Code)
+	}
+	if w.Body.String() != `"Incorrect Unit for minting"` {
+		t.Errorf("Expected `Incorrect Unit for minting`, got %s", w.Body.String())
+	}
+
+	// melt quote with incorrect unit
+	w = httptest.NewRecorder()
+	meltQuoteRequest := cashu.PostMeltQuoteBolt11Request{
+		Request: "dummyrequest",
+		Unit:    "Milsat",
+	}
+	jsonRequestBody, _ = json.Marshal(meltQuoteRequest)
+
+	req = httptest.NewRequest("POST", "/v1/melt/quote/bolt11", strings.NewReader(string(jsonRequestBody)))
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Errorf("Expected status code 400, got %d", w.Code)
+	}
+	fmt.Println("body:  ", w.Body.String())
+
+	if w.Body.String() != `"Incorrect Unit for melting"` {
+		t.Errorf("Expected `Incorrect Unit for melting`, got %s", w.Body.String())
+	}
 
 }

--- a/internal/routes/bolt11.go
+++ b/internal/routes/bolt11.go
@@ -36,6 +36,12 @@ func v1bolt11Routes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint
 			c.JSON(400, "Malformed body request")
 			return
 		}
+		// TODO - REMOVE this when doing multi denomination tokens with Milisats
+		if mintRequest.Unit != cashu.Sat.String() {
+			log.Printf("Incorrect Unit for minting: %+v", mintRequest.Unit)
+			c.JSON(400, "Incorrect Unit for minting")
+			return
+		}
 
 		if mintRequest.Amount == 0 {
 			c.JSON(400, "amount missing")
@@ -175,6 +181,7 @@ func v1bolt11Routes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint
 
 		for _, blindMessage := range mintRequest.Outputs {
 			amountBlindMessages += blindMessage.Amount
+			// check all blind messages have the same unit
 		}
 		blindedSignatures := []cashu.BlindSignature{}
 		recoverySigsDb := []cashu.RecoverSigDB{}
@@ -319,6 +326,13 @@ func v1bolt11Routes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint
 		if err != nil {
 			log.Printf("Incorrect body: %+v", err)
 			c.JSON(400, "Malformed body request")
+			return
+		}
+
+		// TODO - REMOVE this when doing multi denomination tokens with Milisats
+		if meltRequest.Unit != cashu.Sat.String() {
+			log.Printf("Incorrect Unit for minting: %+v", meltRequest.Unit)
+			c.JSON(400, "Incorrect Unit for melting")
 			return
 		}
 
@@ -481,6 +495,7 @@ func v1bolt11Routes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint
 			c.JSON(500, "Opps!, something went wrong")
 			return
 		}
+
 		if quote.Melted {
 			c.JSON(400, "Quote already melted")
 			return
@@ -501,6 +516,13 @@ func v1bolt11Routes(ctx context.Context, r *gin.Engine, pool *pgxpool.Pool, mint
 			mint.RemoveQuotesAndProofs(quote.Quote, meltRequest.Inputs)
 			log.Printf("CheckProofsAreSameUnit: %+v", err)
 			c.JSON(400, "Proofs are not the same unit")
+			return
+		}
+		// TODO - REMOVE this when doing multi denomination tokens with Milisats
+		if unit != cashu.Sat {
+			log.Printf("Incorrect Unit for minting: %+v", unit)
+			mint.RemoveQuotesAndProofs(quote.Quote, meltRequest.Inputs)
+			c.JSON(400, "Incorrect Unit for minting")
 			return
 		}
 


### PR DESCRIPTION
This will make a check using the type Sat only. There was worry about a vulnerability where giving the wrong unit would cause the mint to payout a bigger amount if passed the incorrect unit. 

There are 3 checks happening before doing a  mint:
- is it the same unit type (Right now it also checks for Sat unit specifically)?
- is there amount blindMessages equal to the invoice amounts ?
- was the payment received?

for melting there are 4 checks:
- is it the same unit type? Right now it also checks for Sat unit specifically
- is there amount proofs  equal to the invoice amounts ?
- are proof correctly signed? The way this gets checked by doing a search of the keyset using the unit type as reference.
- was payment successful?