### PR TITLE
Sig all stream fixes

### DIFF
--- a/api/cashu/auth.go
+++ b/api/cashu/auth.go
@@ -44,7 +44,7 @@ func (a AuthProof) Y() (WrappedPublicKey, error) {
 	y, err := gonutsCrypto.HashToCurve(parsedSecret)
 
 	if err != nil {
-		return WrappedPublicKey{}, fmt.Errorf("crypto.HashToCurve: %+v", err)
+		return WrappedPublicKey{}, fmt.Errorf("crypto.HashToCurve: %w", err)
 	}
 
 	return WrappedPublicKey{y}, nil
@@ -106,14 +106,14 @@ func DecodeAuthToken(tokenstr string) (AuthProof, error) {
 	if err != nil {
 		tokenBytes, err = base64.RawURLEncoding.DecodeString(base64Token)
 		if err != nil {
-			return AuthProof{}, fmt.Errorf("error decoding token: %v", err)
+			return AuthProof{}, fmt.Errorf("error decoding token: %w", err)
 		}
 	}
 
 	var authProof AuthProof
 	err = json.Unmarshal(tokenBytes, &authProof)
 	if err != nil {
-		return AuthProof{}, fmt.Errorf("cbor.Unmarshal: %v", err)
+		return AuthProof{}, fmt.Errorf("cbor.Unmarshal: %w", err)
 	}
 
 	return authProof, nil

--- a/api/cashu/compat_helpers_test.go
+++ b/api/cashu/compat_helpers_test.go
@@ -1,0 +1,274 @@
+package cashu
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type compatProofEnvelope struct {
+	Inputs Proofs `json:"inputs"`
+}
+
+var compatUnixTime *int64
+
+func decodeProofsFromPayload(t *testing.T, payload []byte) Proofs {
+	t.Helper()
+	var envelope compatProofEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		t.Fatalf("json.Unmarshal(proof payload): %v", err)
+	}
+	return envelope.Inputs
+}
+
+func decodeSwapRequest(t *testing.T, payload []byte) PostSwapRequest {
+	t.Helper()
+	var request PostSwapRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("json.Unmarshal(swap payload): %v", err)
+	}
+	return request
+}
+
+func decodeMeltRequest(t *testing.T, payload []byte) PostMeltBolt11Request {
+	t.Helper()
+	var request PostMeltBolt11Request
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("json.Unmarshal(melt payload): %v", err)
+	}
+	return request
+}
+
+func setCompatUnixTime(t *testing.T, unix int64) {
+	t.Helper()
+	compatUnixTime = &unix
+	t.Cleanup(func() {
+		compatUnixTime = nil
+	})
+}
+
+func validateProofsWithLocalValidators(proofs Proofs) error {
+	if compatUnixTime != nil {
+		return validateProofsWithCompatTime(proofs, *compatUnixTime)
+	}
+
+	for _, proof := range proofs {
+		isLocked, spendCondition, err := proof.IsProofSpendConditioned()
+		if err != nil {
+			return err
+		}
+		if !isLocked || spendCondition == nil {
+			return ErrInvalidSpendCondition
+		}
+
+		switch spendCondition.Type {
+		case P2PK:
+			valid, err := proof.VerifyP2PK(spendCondition)
+			if err != nil {
+				return err
+			}
+			if !valid {
+				return ErrInvalidSpendCondition
+			}
+		case HTLC:
+			valid, err := proof.VerifyHTLC(spendCondition)
+			if err != nil {
+				return err
+			}
+			if !valid {
+				return ErrInvalidSpendCondition
+			}
+		default:
+			return ErrInvalidSpendCondition
+		}
+
+		if err := VerifyProofCondition(proof); err != nil {
+			return err
+		}
+	}
+
+	return VerifyProofsSpendConditions(proofs)
+}
+
+func validateProofsWithCompatTime(proofs Proofs, currentUnix int64) error {
+	for _, proof := range proofs {
+		if err := validateProofConditionWithCompatTime(proof, currentUnix); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateProofConditionWithCompatTime(proof Proof, currentUnix int64) error {
+	isLocked, spendCondition, err := proof.IsProofSpendConditioned()
+	if err != nil {
+		return fmt.Errorf("proof.IsProofSpendConditioned(). %w", err)
+	}
+	if isLocked {
+		if err := spendCondition.CheckValid(); err != nil {
+			return fmt.Errorf("spendCondition.CheckValid(). %w", err)
+		}
+		switch spendCondition.Type {
+		case P2PK:
+			if err := validateP2PKProofWithCompatTime(proof, spendCondition, currentUnix); err != nil {
+				return err
+			}
+		case HTLC:
+			if err := validateHTLCProofWithCompatTime(proof, spendCondition, currentUnix); err != nil {
+				return err
+			}
+		default:
+			return ErrInvalidSpendCondition
+		}
+	}
+	if !isLocked && len(proof.Secret) != 64 {
+		return ErrCommonSecretNotCorrectSize
+	}
+	return nil
+}
+
+func validateP2PKProofWithCompatTime(proof Proof, spendCondition *SpendCondition, currentUnix int64) error {
+	witness, err := proof.parseWitness()
+	if err != nil {
+		return fmt.Errorf("p.parseWitness(). %w", err)
+	}
+	if compatTimelockPassed(spendCondition, currentUnix) {
+		valid, _ := proof.verifyTimelockPassedSpendCondition(spendCondition, witness)
+		if valid {
+			return nil
+		}
+	}
+	valid, err := proof.verifyP2PKSpendCondition(spendCondition, witness)
+	if err != nil {
+		return fmt.Errorf("p.verifyP2PKSpendCondition(spendCondition, witness). %w", err)
+	}
+	if !valid {
+		return ErrInvalidSpendCondition
+	}
+	return nil
+}
+
+func validateHTLCProofWithCompatTime(proof Proof, spendCondition *SpendCondition, currentUnix int64) error {
+	witness, err := proof.parseWitness()
+	if err != nil {
+		return fmt.Errorf("p.parseWitness(). %w", err)
+	}
+	if compatTimelockPassed(spendCondition, currentUnix) {
+		valid, _ := proof.verifyTimelockPassedSpendCondition(spendCondition, witness)
+		if valid {
+			return nil
+		}
+	}
+	valid, err := proof.verifyHtlcSpendCondition(spendCondition, witness)
+	if err != nil {
+		return fmt.Errorf("p.verifyHtlcSpendCondition(spendCondition, witness). %w", err)
+	}
+	if !valid {
+		return ErrInvalidSpendCondition
+	}
+	return nil
+}
+
+func compatTimelockPassed(spendCondition *SpendCondition, currentUnix int64) bool {
+	return spendCondition.Data.Tags.Locktime != 0 && currentUnix > int64(spendCondition.Data.Tags.Locktime)
+}
+
+func validateSwapRequestForCompat(request PostSwapRequest) error {
+	if compatUnixTime == nil {
+		return request.ValidateSigflag()
+	}
+	return validateSwapRequestWithCompatTime(request, *compatUnixTime)
+}
+
+func validateSwapRequestWithCompatTime(request PostSwapRequest, currentUnix int64) error {
+	sigAllCheck, err := checkForSigAll(request.Inputs)
+	if err != nil {
+		return fmt.Errorf("checkForSigAll(request.Inputs). %w", err)
+	}
+	if sigAllCheck.sigFlag == SigAll {
+		firstProof := request.Inputs[0]
+		firstSpendCondition, err := firstProof.parseSpendCondition()
+		if err != nil {
+			return fmt.Errorf("request.Inputs[0].parseSpendCondition(). %w", err)
+		}
+		firstWitness, err := firstProof.parseWitness()
+		if err != nil {
+			return fmt.Errorf("request.Inputs[0].parseWitness(). %w", err)
+		}
+		if firstSpendCondition == nil || firstWitness == nil {
+			return ErrInvalidSpendCondition
+		}
+		if err := request.verifySigAllRepetition(); err != nil {
+			return fmt.Errorf("request.verifySigAllRepetition(). %w", err)
+		}
+		msg := request.makeSigAllMsg()
+		if err := checkSigAllProofValidWithCompatTime(msg, sigAllCheck, firstProof, currentUnix); err != nil {
+			return fmt.Errorf("checkSigAllProofValidWithCompatTime(msg, sigAllCheck, firstProof, currentUnix). %w", err)
+		}
+	}
+	return nil
+}
+
+func validateMeltRequestForCompat(request PostMeltBolt11Request) error {
+	return request.ValidateSigflag()
+}
+
+func checkSigAllProofValidWithCompatTime(sigAllMsg string, sigAllValidation SigflagValidation, firstProof Proof, currentUnix int64) error {
+	if sigAllValidation.sigFlag != SigAll {
+		return fmt.Errorf("sigAllValidation has flag that is not SIG_ALL")
+	}
+
+	spendCondition, err := firstProof.parseSpendCondition()
+	if err != nil {
+		return fmt.Errorf("firstProof.parseSpendCondition(). %w", err)
+	}
+	witness, err := firstProof.parseWitness()
+	if err != nil {
+		return fmt.Errorf("firstProof.parseWitness(). %w", err)
+	}
+	if spendCondition == nil || witness == nil {
+		return ErrInvalidSpendCondition
+	}
+
+	if compatTimelockPassed(spendCondition, currentUnix) {
+		signatures, err := checkSigAllValidSignature(sigAllMsg, sigAllValidation.refundPubkeys, witness.Signatures)
+		if err != nil {
+			return fmt.Errorf("checkSigAllValidSignature(msg, refundPubkeys, witness.Signatures). %w", err)
+		}
+		if signatures >= sigAllValidation.signaturesRequiredRefund {
+			return nil
+		}
+	}
+
+	if sigAllValidation.proofType == HTLC {
+		if err := spendCondition.VerifyPreimage(witness); err != nil {
+			return fmt.Errorf("spendCondition.VerifyPreimage(witness). %w", err)
+		}
+	}
+
+	signatures, err := checkSigAllValidSignature(sigAllMsg, sigAllValidation.pubkeys, witness.Signatures)
+	if err != nil {
+		return fmt.Errorf("checkSigAllValidSignature(msg, pubkeys, witness.Signatures). %w", err)
+	}
+	if signatures < sigAllValidation.signaturesRequired {
+		return ErrNotEnoughSignatures
+	}
+	return nil
+}
+
+func assertCompatError(t *testing.T, err error, wantErr error) {
+	t.Helper()
+	if wantErr == nil {
+		if err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("expected error %v, got success", wantErr)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+}

--- a/api/cashu/compat_melt_sigall_scenarios_test.go
+++ b/api/cashu/compat_melt_sigall_scenarios_test.go
@@ -1,0 +1,200 @@
+package cashu
+
+import "testing"
+
+func TestCompatibility_melt_p2pk_sigall_unsigned_fails(t *testing.T) {
+	payload := []byte(`{
+  "quote": "ULhtduLerz8ekrdAeo-XEfIli_CZ1M5CnEKg5Wwf",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"ceb30c1d9a04e91bc7e0aab532791a0cccb9c97079c3641c36d8b6c78f319c33\",\"data\":\"02ab65f50ab5c4cc106041d686ab91b82c7bfcc6d7bb6dfa529f2694d514d752cb\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02690ea806c18255c047f8f82ea3860f9091444ffe5320912b3c0e3d2cef160503"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"0d59ff41253755a71113757445f49344b6b503df8a674c829bc9be7c7e36010a\",\"data\":\"02ab65f50ab5c4cc106041d686ab91b82c7bfcc6d7bb6dfa529f2694d514d752cb\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0360449757382b80d4e0a869fa429f95a129a8d1746da333fc58fbd260972ca1d0"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_p2pk_sigall_unsigned_fails label=melt_P2PK_SIG_ALL_unsigned\n%s", payload)
+	request1 := decodeMeltRequest(t, payload)
+	err := validateMeltRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+}
+
+func TestCompatibility_melt_p2pk_sigall_sig_inputs_fail(t *testing.T) {
+	payload := []byte(`{
+  "quote": "c_2sg6Ipsqkt4baNszjh59XQwOtrym_gTnHk6tNE",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"161dd7adcb4b7a18c6f395bf849d8b201cd6cab9494a32917536d9ac2f8f993f\",\"data\":\"03c4a8af6aaf0f49af5556a047c9ec38483ee08a7de5bbcad9f1105906c86230df\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "031ceba7ddeb8c544811f0153b1b3c013b5badcbc367169119eedb8fc2cd86b3be",
+      "witness": "{\"signatures\":[\"b04a25301cdab6161affed1501b508ca8bb37d15ed03a3e2602d8e681506bc7a2f9db1d80db7bd9076a15253cd4fc4ed6b19531b96d79613466dae908804a0b6\"]}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"a73d6231e6e3647c4b6d6abd52fa72e5f755fc4ba9e0315402220277c2c1fa8a\",\"data\":\"03c4a8af6aaf0f49af5556a047c9ec38483ee08a7de5bbcad9f1105906c86230df\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02b317ebc9de5c3105dad7c7448c54325cdab30d846496dc2220cae39a01dbf093",
+      "witness": "{\"signatures\":[\"9ef488ba1e62299896e6e180a752fccc35f41a37dd611d0c761f6dd577e0c7ba3f42f92789071e6453c4181a269cb21ed1691eec089653912b83e94d2da95be2\"]}"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_p2pk_sigall_sig_inputs_fail label=melt_P2PK_SIG_ALL_sig_inputs\n%s", payload)
+	request1 := decodeMeltRequest(t, payload)
+	err := validateMeltRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+}
+
+func TestCompatibility_melt_p2pk_sigall_transaction_signature_succeeds(t *testing.T) {
+	payload := []byte(`{
+  "quote": "ZYyOhmwSPctq5zmUk_DiNQ_BZnpTPH9hMenBovPN",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"802a03ad1daad1fadd4e2f54030797629b4524cfd09ea785869c6df42948535c\",\"data\":\"033b987d4730010dc06a7215527195b6fe0ee977c06bfc1d397f2ac5be9a964043\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03b917317dcd5c0fa18760b5f82f60210c28446c15b3ee9753daedcf2a85dd132a",
+      "witness": "{\"signatures\":[\"c6e2581c3fdceb20eeb0643152c7033ce98eaf3078ecbea4b3b0e892ac870dfaec0476dd0919e942c7f02ba637bd58cb1a5d35398bed135cc6a5e472d4cb09b4\"]}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"c3ab0956f6dc5ed639bb842f6bd755307e7b69cf0f29922c4c5c1c023cdf2b09\",\"data\":\"033b987d4730010dc06a7215527195b6fe0ee977c06bfc1d397f2ac5be9a964043\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03981b658927fbbc3e52b9f796b2ca137a7f70d2cd3a5b11b51fefdedf1463844b"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_p2pk_sigall_transaction_signature_succeeds label=melt_P2PK_SIG_ALL_valid\n%s", payload)
+	request1 := decodeMeltRequest(t, payload)
+	err := validateMeltRequestForCompat(request1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_melt_htlc_sigall_preimage_only_no_pubkeys_succeeds(t *testing.T) {
+	payload := []byte(`{
+  "quote": "hnAeFmaURIBM2yB2BRrBJUGxLnHU73F_4MuL_MhW",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"2d76007ab96399629d21fc8b1ed913a042e1352e7b8ce04b3f767695b5f436f7\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02c1e6837f590b4d131bedc72df4e3a527e1fd328df75fee3d5dbf26789d2fd8f4",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\"}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"d870b2c4cb5a4c0df25939244b93fd8d393ea74d72f48abaedabd5eda3ad0a6c\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "025a1b9b53063f55b29d0c6c4230173a84d0c7cbef6d6ba3cbde1290957fcdb4c2"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_htlc_sigall_preimage_only_no_pubkeys_succeeds label=melt_HTLC_SIG_ALL_preimage_only_without_pubkeys\n%s", payload)
+	request1 := decodeMeltRequest(t, payload)
+	err := validateMeltRequestForCompat(request1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_melt_htlc_sigall_preimage_only_fails(t *testing.T) {
+	payload := []byte(`{
+  "quote": "Jo3mh0trrfmHUo642UhwCn4kbYSQghHjahCvVLst",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"80a2a75f5f332c2525c2c5bc4297bf7ec5339e958a88652f5758f83a251bbdde\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"02395d6d4f521bdac6505c9a22034f5502d48aa42348787898ac9698a76557b67c\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "036d176147191ce1a451aad23d34a6e4d603a338df6b72628208e766a1072b8f65",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\"}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"4bb926f87e7e4c5897ccb9f5879b9b572210b20650b1d8d80f842f57e2695cc8\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"02395d6d4f521bdac6505c9a22034f5502d48aa42348787898ac9698a76557b67c\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0239ce14376282f3a1aa1b78c5a1c5c46bc6baa1da2db01d16a400eb1dee8d0468"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_htlc_sigall_preimage_only_fails label=melt_HTLC_SIG_ALL_preimage_only\n%s", payload)
+	request1 := decodeMeltRequest(t, payload)
+	err := validateMeltRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+}
+
+func TestCompatibility_melt_htlc_sigall_sig_inputs_fail(t *testing.T) {
+	payload := []byte(`{
+  "quote": "Y6Un-XshIzyNdIzw_TR5GfMu3On6oG6kzV18yI_5",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"61e7557f73bb2663b61611928d35d23fe3b03ef183a2fe7de2f5a441698b4b62\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03c4591a678d053a56800a055d1a41653aa1e861851dffa841634f0a9c6400b4e2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02377779237f25faa3c9a0922623645e6bebd52f0927fb6413d003ae3ed9d8326f",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"cede4670dd2f8feb3728846e42ff05ff412ad43fa685031819a43a1d6fb672e91b8fb7d61e8c6a533cfb8f37147c58df218d97afbbd179fcaac9c95ed88f9346\"]}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"3ff5e4879f806bae8e39f590de15550e14dd275a2f4661cfa332bc7785e720fe\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03c4591a678d053a56800a055d1a41653aa1e861851dffa841634f0a9c6400b4e2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03d897073a6000635d19f1c5e149022787df223322d3acbbb745a91850c156765b",
+      "witness": "{\"signatures\":[\"a21c071fd81cc19685c63b6dd7fe8764452de064412707055758de893905afc9dabaddf9bba5b62e8e65918d6af921ce38028b2a8f45eae15946a507b606580d\"]}"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_htlc_sigall_sig_inputs_fail label=melt_HTLC_SIG_ALL_sig_inputs\n%s", payload)
+	request1 := decodeMeltRequest(t, payload)
+	err := validateMeltRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+}
+
+func TestCompatibility_melt_htlc_sigall_preimage_and_transaction_signature_succeeds(t *testing.T) {
+	payload := []byte(`{
+  "quote": "-0T4g9sRIXKyr8ZJI-4sfEuEGa1T8llOnVDTErUp",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"bd7543c88474d42669b12f9d35af1eaa716edbad91dab657b03342c8073009fb\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"02338c5f020e19ae581e9e7cf10dcf5f7757f1534e8a1d10d3a0b2e2e7722a1e63\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "021c60653e4b11134fb3c7b65d1dbe10154ee5cb5d28c37969d7301921ffed7e4f",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"cb037fc25dee074dec3ca5346761b6c62cbb8f9f3976351c9ab350be53e8345e8c58e8265245435dec72134fa433b279f3bb406bd1796751e0c87362d47d73fd\"]}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"bdc66f2db4d3cf7aba92bb9d386bf9a93e1457b1997d51297fd9cc9fe706dcad\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"02338c5f020e19ae581e9e7cf10dcf5f7757f1534e8a1d10d3a0b2e2e7722a1e63\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0375afff1d994f31b502fdd66027dcf7d2bfd0a46523fd02e2a17c288ebd005f13"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_htlc_sigall_preimage_and_transaction_signature_succeeds label=melt_HTLC_SIG_ALL_valid\n%s", payload)
+	request1 := decodeMeltRequest(t, payload)
+	err := validateMeltRequestForCompat(request1)
+	assertCompatError(t, err, nil)
+}

--- a/api/cashu/compat_proof_scenarios_test.go
+++ b/api/cashu/compat_proof_scenarios_test.go
@@ -1,0 +1,1094 @@
+package cashu
+
+import "testing"
+
+func TestCompatibility_p2pk_swap_unsigned_fails(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"072dd1bbb55aa17a9998fe89284c4555c523adb70239f00bdd91075f9c98055a\",\"data\":\"03648c241674db282ee7731b0f82b7d840972ce1e8236f610dfca0e67f007dddfe\"}]",
+      "C": "03d865193f379a49e83fcc0226d2df30d4f49e84d9393f93074e7fee00d96d668f"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"dd94f0fbd27eb3353b60cc94e4043c2028b3e48e5c1c97e99a4d49691bdfcd62\",\"data\":\"03648c241674db282ee7731b0f82b7d840972ce1e8236f610dfca0e67f007dddfe\"}]",
+      "C": "026cbeb8477ea448f88dfc3bf0e6463ebd1f2739ee31009d4f498c963bae49d8bd"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02ebb7a5486cf24920207d1fd0272ae35c589df20c1973c3070727e52a6a64a08b"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "026d65e40128568704d03510ca536ac29ccab98d41b619e992cc93705f1fc49236"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_swap_unsigned_fails label=unsigned_P2PK_spend\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrNoValidSignatures)
+}
+
+func TestCompatibility_p2pk_partial_signatures_fail(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"dc42f259986b9317d74011e02646cdb17b75c774c5060644acf38e400550291a\",\"data\":\"033b5930fc850660fdc78e83ab6c938ce341b232402261df02b258a511af1c5124\"}]",
+      "C": "02a2abed79a6decbd61b9590a162b2e51b63c809af11530c20e1dd557b653a7765",
+      "witness": "{\"signatures\":[\"afe259d70fbe0fbaa11249321cf689db27a43406395f954e5cb69456582051ab9a93badd6ff5761b029725d5ca13250b3b2836e9757aca166eb3a20726bb7188\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"d16098101afdc7ede91caea2535a39ee8ba098fb0e56769fa9de746fbebbc0d7\",\"data\":\"033b5930fc850660fdc78e83ab6c938ce341b232402261df02b258a511af1c5124\"}]",
+      "C": "037b8829e23270f414aaa5e8079469671e00ba7d9d9e8b91dc564cb856d88c873c"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02ec1eab2ce74cb8114cfafeb45a3304cb2b4a5c1f7d8948b91fc4eea66bf47bae"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03b5c19534de02b7b0e10d88b9822ff3c81c1d23a622d0d8278d89e89aa2433d9e"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_partial_signatures_fail label=partial_signature_P2PK_spend\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrNoValidSignatures)
+}
+
+func TestCompatibility_p2pk_swap_signed_succeeds(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"427160eeca48319454886202ee998efb8c9c65703823ad4418a09e51e05c3c0a\",\"data\":\"0353a091a76a5cdd23c87a1508141b14505c71d5d4bc57f59777127c89f82e845f\"}]",
+      "C": "03ab9d11b29d0384ba645ac01f5846bba3748216344bdd11a525b4301f67bf9aa3",
+      "witness": "{\"signatures\":[\"bfbe10277a8e932d186009d54e6d2817fb3a2dc174440a456fd8d04915632c9cff87d2ab98b738e0f2a82de750b11ac3c6b8d7fa4337fcf75bf428c579c33fed\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"4addc3664bc2a19a49a3340e07f244554b459dc446346a1878fe8bcd2f542dd2\",\"data\":\"0353a091a76a5cdd23c87a1508141b14505c71d5d4bc57f59777127c89f82e845f\"}]",
+      "C": "02319644fcc2bc92a7c6ee21e337b746080a8250199a2f80fb400c340581f9b3e7",
+      "witness": "{\"signatures\":[\"c94779eec6d1d42378afb6a775fa0454fb9bf060763b8aeab9f9347732a2f2716d067dca67b619226a2faf658191cc9e51a6c7a6baec8d63b53de27c6616b0b0\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03ee692551408bb2a7e419b40e5261a82032034e919acab462a880945fdfb187f7"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "022fce7da081365fc2c8c1b07c27af3a9f570c4daf309b9b30bb337c8f38916044"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_swap_signed_succeeds label=signed_P2PK_spend\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_multisig_2of3(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"179d809937cfde2900a8975acdef44bcf94939fcd4be81b0ab13da0db87bde63\",\"data\":\"034d254efea16189df43172be881000cfdac169e3fc333f6253eabe8f583d2610d\",\"tags\":[[\"pubkeys\",\"031042be3bce245f85e95e845f66ec212676d303b23a5a1328c53d1f8da6a13b07\",\"02d8c1562b1e56b9c313b420565b0d90fe5a54f1386bc96f8fe4e5d0878c3a7f81\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "0306473db7ef6175c34af0726f802cf1f4ff083bb2fe563883a52c53387070e195",
+      "witness": "{\"signatures\":[\"6f6cf63567eb74d230f05d3f32fd624160a61d9bc923975d1b98fc4536379c7ff38928294baba0d35616a254a7d2a67eeb6e1d99de43d9c66381c9997fbc4dcb\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"0726e906644e9f1b586d052bd0911956a4cedbce0b6943fbf1b468b15636026f\",\"data\":\"034d254efea16189df43172be881000cfdac169e3fc333f6253eabe8f583d2610d\",\"tags\":[[\"pubkeys\",\"031042be3bce245f85e95e845f66ec212676d303b23a5a1328c53d1f8da6a13b07\",\"02d8c1562b1e56b9c313b420565b0d90fe5a54f1386bc96f8fe4e5d0878c3a7f81\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02b8b05f1775189302845f0dd1720a8f2964aee060c868dbf6bed237014e32083e",
+      "witness": "{\"signatures\":[\"53c3aec2c5cfb633e3941b30458e8efdebce5527ba6d484ca2c5fbfbc4ec2790b14517dc60094ca8d7b9ed4e55d88288a31c054bb91ec17a27ab1293f41fd33a\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03c3920124f64da2d698efdd0578fe20117310c74f53a847bd420858fc4de64877"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0231ef098089b6ec712698e1d0af9517e744f4dc79a4d91ae53bbeee74fbef2d06"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_multisig_2of3 label=1_of_2_multisig\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+
+	payload2 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"179d809937cfde2900a8975acdef44bcf94939fcd4be81b0ab13da0db87bde63\",\"data\":\"034d254efea16189df43172be881000cfdac169e3fc333f6253eabe8f583d2610d\",\"tags\":[[\"pubkeys\",\"031042be3bce245f85e95e845f66ec212676d303b23a5a1328c53d1f8da6a13b07\",\"02d8c1562b1e56b9c313b420565b0d90fe5a54f1386bc96f8fe4e5d0878c3a7f81\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "0306473db7ef6175c34af0726f802cf1f4ff083bb2fe563883a52c53387070e195",
+      "witness": "{\"signatures\":[\"a96a4a91d04851a26548de82cef4ebe0dcb30b25973073aebaf4f473c89579d22cb7a7acf823b9a2f4b0108753795e932d36b65b289725da7211a3b509361f93\",\"3d6c37d2f33c7a55458baf945058fd69f531a3276d87bdbe8ca54af77125cc3fb2d3864c2e725c99045af4ec62629f4cee54ff2bbd8650f3391aa4b972dde6c2\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"0726e906644e9f1b586d052bd0911956a4cedbce0b6943fbf1b468b15636026f\",\"data\":\"034d254efea16189df43172be881000cfdac169e3fc333f6253eabe8f583d2610d\",\"tags\":[[\"pubkeys\",\"031042be3bce245f85e95e845f66ec212676d303b23a5a1328c53d1f8da6a13b07\",\"02d8c1562b1e56b9c313b420565b0d90fe5a54f1386bc96f8fe4e5d0878c3a7f81\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02b8b05f1775189302845f0dd1720a8f2964aee060c868dbf6bed237014e32083e",
+      "witness": "{\"signatures\":[\"1d3e6083099052aeb7f2aa4213be61ea7476085fd85881cc488e5186c253666e46330fa1bf3cb40fdc4a9bb766dab86e1840f5b0a1eee47c1f8dc6fe91f2583a\",\"ae33e04f204063f1b91ef24f12f7059addee0445cdc8b63b278115263c43f60526a40e75b9f5dab08b57070439cb412e6522516112b6b744b4d19264181f6ba7\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03c3920124f64da2d698efdd0578fe20117310c74f53a847bd420858fc4de64877"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0231ef098089b6ec712698e1d0af9517e744f4dc79a4d91ae53bbeee74fbef2d06"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_multisig_2of3 label=invalid_multisig\n%s", payload2)
+	proofs2 := decodeProofsFromPayload(t, payload2)
+	err = validateProofsWithLocalValidators(proofs2)
+	assertCompatError(t, err, ErrNoValidSignatures)
+
+	payload3 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"179d809937cfde2900a8975acdef44bcf94939fcd4be81b0ab13da0db87bde63\",\"data\":\"034d254efea16189df43172be881000cfdac169e3fc333f6253eabe8f583d2610d\",\"tags\":[[\"pubkeys\",\"031042be3bce245f85e95e845f66ec212676d303b23a5a1328c53d1f8da6a13b07\",\"02d8c1562b1e56b9c313b420565b0d90fe5a54f1386bc96f8fe4e5d0878c3a7f81\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "0306473db7ef6175c34af0726f802cf1f4ff083bb2fe563883a52c53387070e195",
+      "witness": "{\"signatures\":[\"8f821eb524a41131cc488aa8eab821b0c157ce8cdd8d6a2dca6745e7d29e3aa5f31e5de05559da8cfad6d524d468389ed0ff31a2985e6953b21cfe4714f64f9d\",\"9e973ba2505c26137f79f11c9088d68bfdb0060c8ce07489d6b0a861eac84e7b7b199a9f96c58219b13410619628a443868d034b7c0e905b670a266ac4e78560\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"0726e906644e9f1b586d052bd0911956a4cedbce0b6943fbf1b468b15636026f\",\"data\":\"034d254efea16189df43172be881000cfdac169e3fc333f6253eabe8f583d2610d\",\"tags\":[[\"pubkeys\",\"031042be3bce245f85e95e845f66ec212676d303b23a5a1328c53d1f8da6a13b07\",\"02d8c1562b1e56b9c313b420565b0d90fe5a54f1386bc96f8fe4e5d0878c3a7f81\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02b8b05f1775189302845f0dd1720a8f2964aee060c868dbf6bed237014e32083e",
+      "witness": "{\"signatures\":[\"8fff33f982153d1ffb40ba4305512274083404390c53dd7d7342aea61056aa97dcbf9b353d136558751afa52bb812cd1c85218c63317e0d90799a0a9edb9c106\",\"dece91cf7b07b90734b987af3d573c831f8f061762863917f38b8099ce448619a13aa7b28dbb7560ddd85844d36ceef542fe09dbdfc8a9be7443f006538ddc2c\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03c3920124f64da2d698efdd0578fe20117310c74f53a847bd420858fc4de64877"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0231ef098089b6ec712698e1d0af9517e744f4dc79a4d91ae53bbeee74fbef2d06"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_multisig_2of3 label=valid_multisig\n%s", payload3)
+	proofs3 := decodeProofsFromPayload(t, payload3)
+	err = validateProofsWithLocalValidators(proofs3)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_locktime_before_expiry_primary_only(t *testing.T) {
+	setCompatUnixTime(t, 1781734543)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"055779983e8894fb8c05846d0385c09cb8af34c9aee0d4fc66eca330a210fb02\",\"data\":\"02ae6a02921408fac78719941f38a5c73e68771b2c19d361c4e82886f06e13f444\",\"tags\":[[\"locktime\",\"1781734544\"],[\"refund\",\"02afab98512efa342052a068ac3abd3e7b9281705dd0e4b322d1469817f063416d\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02bbe99f7e2b9178e8ee8b57ccaf1393ee0408f9c6317cd87399d96d1f75ed6058",
+      "witness": "{\"signatures\":[\"69ab99768b53bb47ae9d46bf37aefdd214ade12871e882823ed6d93c3f6e4489862a5b10d2f593813a086b51935a03b60208b34a91100b77a98c42f2a1294327\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"68f3a6a8613b3509a9fde51322e2a360c4a67f6b778ebfa183b2170503b523c9\",\"data\":\"02ae6a02921408fac78719941f38a5c73e68771b2c19d361c4e82886f06e13f444\",\"tags\":[[\"locktime\",\"1781734544\"],[\"refund\",\"02afab98512efa342052a068ac3abd3e7b9281705dd0e4b322d1469817f063416d\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "028553d7190f007147658238bb89bda449d5aebadd9439f9a19addd6d625bc15e6",
+      "witness": "{\"signatures\":[\"76fecf60ccb11b0d98aa38afb6657cdfb38e85fd59ec679993503c017beda846e631cb409ab2c504e3caac2837b69bd6d37d8550107d6b341cdffa219fffd714\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "032fcdd4b7626c0f0c3c6c914befc746ab989bbeb8a68bf80bc703edf8f4c817aa"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02c5564ee85e29b392258c97c62068bb4ffcdcd8d527db366be5a62cf8445d5303"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_locktime_before_expiry_primary_only label=refund_before_locktime\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrNoValidSignatures)
+
+	payload2 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"055779983e8894fb8c05846d0385c09cb8af34c9aee0d4fc66eca330a210fb02\",\"data\":\"02ae6a02921408fac78719941f38a5c73e68771b2c19d361c4e82886f06e13f444\",\"tags\":[[\"locktime\",\"1781734544\"],[\"refund\",\"02afab98512efa342052a068ac3abd3e7b9281705dd0e4b322d1469817f063416d\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02bbe99f7e2b9178e8ee8b57ccaf1393ee0408f9c6317cd87399d96d1f75ed6058",
+      "witness": "{\"signatures\":[\"f26d262a940792c72e04eee8e14d15713919ec2e3702e51dc30630e6b2874c1db042e43dd44adbf2925efc7767797aa42bfecad8df14017cc697079679326c53\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"68f3a6a8613b3509a9fde51322e2a360c4a67f6b778ebfa183b2170503b523c9\",\"data\":\"02ae6a02921408fac78719941f38a5c73e68771b2c19d361c4e82886f06e13f444\",\"tags\":[[\"locktime\",\"1781734544\"],[\"refund\",\"02afab98512efa342052a068ac3abd3e7b9281705dd0e4b322d1469817f063416d\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "028553d7190f007147658238bb89bda449d5aebadd9439f9a19addd6d625bc15e6",
+      "witness": "{\"signatures\":[\"74c7c86ade7190cd3665751e953ae0f3488b6355f396ca91fc40cf6c00bc07343d33f8676de298b1f1c973e73a574681c0ad6c0f8ff5c06196c2fe70320464f0\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "032fcdd4b7626c0f0c3c6c914befc746ab989bbeb8a68bf80bc703edf8f4c817aa"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02c5564ee85e29b392258c97c62068bb4ffcdcd8d527db366be5a62cf8445d5303"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_locktime_before_expiry_primary_only label=primary_before_locktime\n%s", payload2)
+	proofs2 := decodeProofsFromPayload(t, payload2)
+	err = validateProofsWithLocalValidators(proofs2)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_locktime_after_expiry_primary_still_works(t *testing.T) {
+	setCompatUnixTime(t, 1781727345)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"a1b05e4e81ba5dada29064bd8b16ebc442420e75e7cb088e1bf0107d15995b29\",\"data\":\"030f4aa90fe965ca79ba18a9e7342f64fd2888200ca9d8bfb3851bcf49445c3c5c\",\"tags\":[[\"locktime\",\"1781727344\"],[\"refund\",\"03c4134adcc0ee7fa21269b21133599038efbbba60069528f2dceb7ab269a91174\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "025622f872a2c213c49afdd4b2faa9bfcf005a3f4021408025e1a1cb67d24ef716",
+      "witness": "{\"signatures\":[\"3a3a92371fc7b2fcef4c00fa46518bfe99c000ae66f0b6299de5664900c72534f965060c133a355c00d47fb7aeac8b4584cebb5f453a286df761107639376cec\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"3b23e243897b064a4c2d4e44a68e819c6dc413925144d517085162290cc92b5d\",\"data\":\"030f4aa90fe965ca79ba18a9e7342f64fd2888200ca9d8bfb3851bcf49445c3c5c\",\"tags\":[[\"locktime\",\"1781727344\"],[\"refund\",\"03c4134adcc0ee7fa21269b21133599038efbbba60069528f2dceb7ab269a91174\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "03aa100f86132b17c4416b77c84aa35ec2950745013c5952b51b289ece4dcd5175",
+      "witness": "{\"signatures\":[\"3a7fe7d8fc9081829b793899b04b8b178f4a737e53cd5d24abb936544e7b5712aaf1e418de0d52a08ff9db6298c11afad58c4bb66d032b57549e8cc298a5e905\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02ddee3ae949e0914a9b63da9d1f4ad1b8bb5bdde47ad3956d1a62f31709ff942e"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03d7d3527ce4ccef70786c1f2944d940f19d5954833b63dea9b0ce1822deb799de"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_locktime_after_expiry_primary_still_works label=primary_after_locktime\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_locktime_after_expiry_no_refund_anyone_can_spend(t *testing.T) {
+	setCompatUnixTime(t, 1781727346)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"21ca017f2b385b7355346c7d80fa1c36548e0d460081dde9549fee01a7244d03\",\"data\":\"032b93fc35c9e5a90484d6914c1bbc645dc9e9178af0487c0bd94ceb07366f3a7b\",\"tags\":[[\"locktime\",\"1781727345\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02b933602bc210edd5df8ef724a3010680d5ed074a8dd675e318cf7595dfe16af5"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"f8ab8ea3b0bbf3f82413715861b00fb842c757a05b037d9db0f643898dde043c\",\"data\":\"032b93fc35c9e5a90484d6914c1bbc645dc9e9178af0487c0bd94ceb07366f3a7b\",\"tags\":[[\"locktime\",\"1781727345\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "033f18a7c7ae7c769a2ff7d54a3220eaba0b8b162defbce2adb65c4653b22d9b26"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02c8effcbcf9869ba52c42ff7c7fe3d6c41974ce44d64dc7b4fb3eb07df1f146d4"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "031d726cdc2b1bf15640e153111c9a805635efbac0db0c977b7b87af0d8f6fcf5f"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_locktime_after_expiry_no_refund_anyone_can_spend label=anyone_can_spend_after_locktime\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_multisig_locktime_primary_still_works(t *testing.T) {
+	setCompatUnixTime(t, 1781730846)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"b0058af71dbef822fe92eeb33e72c8895c6302cfd6e3ee526ba32c8f11c7f9aa\",\"data\":\"0279d56b70eac71bc05aaac1e8ad623262a7a98390afc9f40e926dd88288eff4e9\",\"tags\":[[\"pubkeys\",\"03a24f7e9ac00c4ae2e2afd0bf88d92de6fd11913f36d99e4dc8fce2ca05767595\",\"02d87a49bdcd746d4a146eeb797babdee13b540fa3830f35074b666a7707274bcc\"],[\"locktime\",\"1781730845\"],[\"n_sigs\",\"2\"],[\"refund\",\"02c07c12dbdb3a747631f58837aae79610ce72c29456c22bec32a9daa46e411df8\",\"022c0c8fbfae2f98f6d1df87b494903296706225a2fa3060fcfdae87f09cf45851\"],[\"n_sigs_refund\",\"1\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02500e7953584e711d188e5ce7a6e4e81c83fe95264949b1c84648f3b4462f2b9c",
+      "witness": "{\"signatures\":[\"7deb10e044f83358432a050d7925796091d1653b2354d78507041d37f2c70e37180ae95793f5f403471137446bdc7cff56bd6283e0476326a0d5bb5f6908d602\",\"0ea5f3f661f3ba590b90a296d95ddd9b95064c96a541ba85c751659879b58f4994c3713eea893a971ae7af8e4743d9b1f6908a28bb6d0517acc222d79e61d41e\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"d0ca85e927ca4d9475b9cdb525b2df2ffd73463fae269bfe54f3e283c79e9905\",\"data\":\"0279d56b70eac71bc05aaac1e8ad623262a7a98390afc9f40e926dd88288eff4e9\",\"tags\":[[\"pubkeys\",\"03a24f7e9ac00c4ae2e2afd0bf88d92de6fd11913f36d99e4dc8fce2ca05767595\",\"02d87a49bdcd746d4a146eeb797babdee13b540fa3830f35074b666a7707274bcc\"],[\"locktime\",\"1781730845\"],[\"n_sigs\",\"2\"],[\"refund\",\"02c07c12dbdb3a747631f58837aae79610ce72c29456c22bec32a9daa46e411df8\",\"022c0c8fbfae2f98f6d1df87b494903296706225a2fa3060fcfdae87f09cf45851\"],[\"n_sigs_refund\",\"1\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "027bfe2e8183a1fa719dd010eb3273c8137bed09eb66d249d5dac885d5a5a10562",
+      "witness": "{\"signatures\":[\"efeffad5e2d28d23c3e974a2b0a78ca2b70a163f677a7c86375082b237d937c10addc39a067f5a459854d92842165c3443b98ee70db5a382b674e8dc523181e5\",\"fc54fb11841311f1adeec36672953deb1b2de7ea7a2dde1353b9204027205415da4112c7b0a904697f5610006b14e76cd9e9ba8ff928cba709d128a1af34b65a\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03074b5eb10ee56a43c6168067ae18b304a3064aaa28d2a87e1f777a99fa0ba7dc"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03b1d072144518c1a854e92965cde96047f861f8be90d6df488034c9684d3850fd"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_multisig_locktime_primary_still_works label=multisig_primary_after_locktime\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_wrong_signer_fails(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"b1e3b6a27794d510b2c2330f7a627dcda9df4556a5f7c50d80ef7e2af16e0946\",\"data\":\"02e72314f6a4da38bf950eb94498cb903e9c4c0224e022403b22cf2b8938db602f\"}]",
+      "C": "02e86fd8c53c09cd8e6079b9dd1d04bb16df1f5160ed7f72e829f95f5befcefe1c",
+      "witness": "{\"signatures\":[\"68fd44f3235721d6f70571cc23586d50d83bc805d4715e31055535a7ea45a4f8b8b35f344d2705039574d9a3dd547485dfa35269cb7ff097d35147dc877d9347\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"6087f926a0d7bbe06ca53c51230af3dd1da622874e76e1e0e6ae1e3f0da035ad\",\"data\":\"02e72314f6a4da38bf950eb94498cb903e9c4c0224e022403b22cf2b8938db602f\"}]",
+      "C": "023bbe22d446620dc3e2f501905f27901597208fb1fb39cc392e879824632e476d",
+      "witness": "{\"signatures\":[\"312776536717b4995215731f4adb42c4de1fdcb1f5d3dd29453137751cb69715793fdae22ab023ef4bfc09b70b17b9003ef1117a8e6f1b08ca1098327cf91017\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0226e4a2086c007a15d77204f1ee7a49ceba89aa9a51722976f6aed8f80b493cd6"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02d05915ac5c43cfcdf0f535636c0f6363d89b94c18dafdb64e85deda6d1aab097"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_wrong_signer_fails label=wrong_signer\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrNoValidSignatures)
+}
+
+func TestCompatibility_p2pk_duplicate_signatures_fail(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"86b946cc0be657701dd16cd04b4c80234c1ce5ade72390504892a2f1f1401a01\",\"data\":\"02fe8183699c5ce1580e1f0ba3dfffd32d6307abc00fa147755140710213b5afdd\",\"tags\":[[\"pubkeys\",\"026d3d74421ba4ce524d272c4f745f5f46079566ea8529d9e7ba3b65d7c7ed3679\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "03bd98178ee942b49d4b0f7926314f75846c8fdcfe3809cb28ce339754d42ae3cb",
+      "witness": "{\"signatures\":[\"278ed5f06897bbfd6afbe80c6dc15151bc1ae1011b0ce2dc48fbaab91a3e08258a4b6c43224f7b2debb335767866bd731afe89218bfbc159963997e051f89fdd\",\"05637c58430ffbd98ef4e5368d56e2cfba3c715d84a40ba8619d77da8b92f6880871916720a6b30c7ccf68235ed60695d45874a40c20ded741028a7915c5de0a\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"6c0fc9bbf3c8444ee7735ca48e04b58300c5ed67e48b70763b12779ee7570949\",\"data\":\"02fe8183699c5ce1580e1f0ba3dfffd32d6307abc00fa147755140710213b5afdd\",\"tags\":[[\"pubkeys\",\"026d3d74421ba4ce524d272c4f745f5f46079566ea8529d9e7ba3b65d7c7ed3679\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02f8d242f40c07b9e08944a6c42be39030d0bc1d4de9c798cabb4ba2de99267946",
+      "witness": "{\"signatures\":[\"0af460b91312b0fcb8e64818f0ec5148736288a4167abe2230f8622701475c28fd969513f113fc3b1b043c10a29e5fb8810342c2ec2ac6f32c74ca1531c42a53\",\"00581b06d6ce4e62ee658d578f2a92fa2dc43e8910331be952752f894ae47ce87533e53b98992e935d3465b54ab9dd577f236ff0fb0067e28e3652b9d92b3559\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03445a429f695b3579bc8c972ab68e02a6ebf6d5ba95070172e47aafb74eb35561"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "023286196a6f45b1cd41a4b5248fa102c344b96b9de4e65822a363352284984a10"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_duplicate_signatures_fail label=duplicate_signatures\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+}
+
+func TestCompatibility_htlc_preimage_only_no_pubkeys_succeeds(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"c75e808e88fe1bb2fb84f56a8362cdb45ac91d15e378c647d54c309af2f2970e\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\"}]",
+      "C": "0209a2f1b35135c8eeb159c10307634bd43317d4e9988d462dffadf49e4b2590fe",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\"}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"5c6ae8608fb7ec52f8b4906b7b74600c2ce5b381747e77289678d7b45f5cb503\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\"}]",
+      "C": "02f883885c4c368c03dfd0371aad26ea724b61f29ef3fb19c1dbd1d77747b690d0",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\"}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0386044335bb707cdf608d78230ba88821f37ba459f28533cb3e24a6d4482578d7"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03a6230398419c5431d80850e67ff033da81b8c380f4cbb2e9b2fb51ecd1787051"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_preimage_only_no_pubkeys_succeeds label=HTLC_preimage_only_without_pubkeys\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_htlc_preimage_only_fails(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"241bb861cd18c4a0e51806131a92687b15a6f68be68d745247b2a8e09344a888\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03662218cb68968b612659914e01b41e09eeeeb4fe94b4b82e58a8d8cec873d504\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "03e45fb7068cb06446891f6af4f71d021595d10a4e05e77d3aebcd89dba6c20166",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\"}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"931e3ccb4bd8a0d4b8d9a55298e2b6b6a4d6e3d0dcf9fe4786182b97f2593a8e\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03662218cb68968b612659914e01b41e09eeeeb4fe94b4b82e58a8d8cec873d504\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "031f14085f598d1c6570f84931c31ba13ca91fc2c26236f2807013f1b78e1e2a6f",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\"}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "037b92a3ea9e9e1c55aed938e818e7feb86790f3953ded1f08419bb8c9de8530d6"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02f30c88b17eda4d009112bbc11c08b948f119259626fca034d0053107611b751d"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_preimage_only_fails label=HTLC_preimage_only\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrNoValidSignatures)
+}
+
+func TestCompatibility_htlc_signature_only_fails(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"b4ee33d05d0e476e1de66b048344abae57cbd9044be7224306b3e56634fbaba3\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03409fbdf017666ee4c165f87c44cb724b001d4865ae6d2784771f2d82d6944480\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02cda1feafbd0765af4242d12abcd2fbc03c876320056de90b2e818f908ac64842",
+      "witness": "{\"signatures\":[\"5abf57496654a08a5ba2d39984b03d22c480e866a8327109ce3dc1ae34bad8aea149eb1379d2d2468076ed3172853634a939f93196f37419ef267abbfb700842\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"d840d035de6d71b4d0ba1b424e1cf4ec4dbe17ded59ff503e93ce9f9a08dd508\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03409fbdf017666ee4c165f87c44cb724b001d4865ae6d2784771f2d82d6944480\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "038656eb39e52eebc93b4f7f4235fe64a6086c7b254df54c693f795c647d7c0bbd",
+      "witness": "{\"signatures\":[\"d2dc110e4414a2926c325a0d933e2d8e45ab3cac5c461af675c52cc7172b61959068b7256f02d756aa1bf6383adba67e84dff4c555ec403943d22a9a25b5b73d\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03c8dc6f48ecc436e8b3a2f0c3bcadbb4403f9ccea8030f757e3f2c79dc3514b25"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03c7293f0bcf8b5ae818e366b0e2d4fb40e2ef3293fbe98f33a079ce1e88640089"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_signature_only_fails label=HTLC_signature_only\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrInvalidPreimage)
+}
+
+func TestCompatibility_htlc_swap_preimage_and_signature_succeeds(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"ad67180ab0603a530bfc7190c40ba2f588d676a9983531da1d5db27c9efd13e3\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"02d836aac21821ec94df177ab6093936ec8716840e5b2a319846a5d24cc5dc89d8\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02eb21b80dc0a93977e62b4292ac4feac71ed6fc1e17244a8b330d2e186e93e83f",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"563a9d999c17d3c81dfcb5d9949be156c69feb34005b6c2840f098d317cfc096f0e18aebf4c722002813495f01d5b0c138f37808fa3f4b144443be1c815e2156\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"27b319864ac33548387e98978e8a369aa2bf73e0f3f29533e7bc18b0fba87866\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"02d836aac21821ec94df177ab6093936ec8716840e5b2a319846a5d24cc5dc89d8\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "0205e7f41a9fede572928b50af41495f7dd4e0bdc51b73a701810ca7ca7578d213",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"63c781f976a9a0a7483b4e935576f99cc5b545b8fe03d3809c339aaab0252733f0a980b3932006ddad6378431e1c39d3c6d5cb999f9ca39fef15802d1b7a57c0\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "028d2575454a0196e2d51852f7546737ef88966160edfed8c37b37cf27057b50f0"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "023bc32d530c47f7f75ce22b736c28f5fa1e2945c7b3a39ff8256dcb2a1bae0723"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_swap_preimage_and_signature_succeeds label=HTLC_valid_spend\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_htlc_wrong_preimage_fails(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"e9d53406ca0d43ad0d6e6711434f442a2c5af304c30ea3d0b8bd648fe1c0e812\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"0333f8fb0944ddb7c7f3769cbf1d70f10e68d349e052f6e95144e6b3b1866b5b88\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "03e62261cf13df606853b3c6d424f407207244c86e875c45a574eb4c4c374cdb03",
+      "witness": "{\"preimage\":\"this_is_the_wrong_preimage\",\"signatures\":[\"8b17c95e765c974a726f38da492453d0a0476db5d346feb660028c5475819d3842994240cac710fcd2bb0d2c75b8ce06a284d414cdba1f08f5c162320def0419\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"f989f7f79582423feffa334afaba1de54ac149979b480d39e7b6ab77ccf66f98\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"0333f8fb0944ddb7c7f3769cbf1d70f10e68d349e052f6e95144e6b3b1866b5b88\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "030214a956cd7a9c870226eb17c830334da72bd923f1a677c6aa40e7206b47107a",
+      "witness": "{\"preimage\":\"this_is_the_wrong_preimage\",\"signatures\":[\"f4c52c1f691768d7cf518cd766baa38c03113556d6a40b5dce5cc2a112f6a92dfbb95dc1077f1de9175646ccecffae2d0d36e90caf6fde301ecca098ede25043\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0318d737e2690073bfb77d094b9e50a0a95e78d4025f79b2a6973dac1c7845dad7"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02db960c51a3c4231535a3e5bca21f7630b96ea6aa8f3375df11d6a1b5f13bc291"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_wrong_preimage_fails label=wrong_HTLC_preimage\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrInvalidHexPreimage)
+}
+
+func TestCompatibility_htlc_locktime_after_expiry_refund_succeeds(t *testing.T) {
+	setCompatUnixTime(t, 1781729948)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"49326881cc767dda545c2c90011693209fa9d83b4f9db7c9152026f651b6a767\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"02c7e6d6ba5be9e2ef2aa14c4eed2bc0ef628f2a0053d5883294f8c4d88b8f545a\"],[\"locktime\",\"1781729947\"],[\"refund\",\"02b5b34ae63fbd25f92dce9d8b4c081292c9e23983dd581a1855889443fa8ac771\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "0339a1fabcafbceb6c952620267c272bb464c872dd3004f5c7b333d3a97e3563ef",
+      "witness": "{\"preimage\":\"\",\"signatures\":[\"e9a3ce7aee137ba155d6966ba0ed15b3e7554b19befe4d85da81aece08f1a31e56e379db76009256404dffcff624362d1d5ea65fe00d23daa621e1dd54e77c31\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"ac2e2566f2056839d70eba30266f7dca19994ab2c74a0308ddfa4c8accd0fbb6\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"02c7e6d6ba5be9e2ef2aa14c4eed2bc0ef628f2a0053d5883294f8c4d88b8f545a\"],[\"locktime\",\"1781729947\"],[\"refund\",\"02b5b34ae63fbd25f92dce9d8b4c081292c9e23983dd581a1855889443fa8ac771\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02c0fa7a5f67de32d1a0be11e966fcf77c479214cdec06473c8130b8fd4ca83bec",
+      "witness": "{\"preimage\":\"\",\"signatures\":[\"dcc7cbc670f777243a058d9334298d67b164fdce3154294ffa305bf6e455a42c9573843365e27f1aeee27fcc1e3f545d64f6a4309ec1a21a90aab61b24eba047\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "032eec278dd66d5955337b6744c5961b58f8f067286023f7b5dfc55f02a99d04ab"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "035de85787b756b3982f5b7e78643971b11c3b08a839a6dfefac23a06a69e63827"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_locktime_after_expiry_refund_succeeds label=HTLC_refund_after_locktime\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_htlc_multisig_2of3(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"a19b075f4cc2d1e9d8e8ccd6722228ee0a8931a20da4f20f5d6fe2d1250b8d1b\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"0208b4ff71800339677991916dab228845e27edd269c77e6aeabe4ed92871bb122\",\"0302a269d2da53cd3585e676984615146a60cd2e98547a4dfb89d035091578ab2a\",\"025b8d335f884def4da987ac40bc2d2b9a37e1a763823422fdb56ce560c2710c0d\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "025d2b0908ce56e2c3a114d6618dc2f7dadb7061029a239d890715bff82aa68e57",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"88d68d8ffe7ac91480006a0231492e7971d1219c4db9d02d9096151217885e77af7c8072f6af8a1de7d6a94ff81ee7798622cd26ebf6613ff4e736e9b18368b2\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"5d1f08bb5655946ed8d519a8a337fca17dfe872e3fbbce6fb978174c3f397637\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"0208b4ff71800339677991916dab228845e27edd269c77e6aeabe4ed92871bb122\",\"0302a269d2da53cd3585e676984615146a60cd2e98547a4dfb89d035091578ab2a\",\"025b8d335f884def4da987ac40bc2d2b9a37e1a763823422fdb56ce560c2710c0d\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "038effbd57c6b62aa0dbcf51340e7d105d95787f8145910d2b31c3e8cf16f2f312",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"4a304896a849db0f39c61e104580f2dfdc1c41bea87e7be724a3843af053518c3fccf015bb5787fd93187fbc3f980a3cd07ef914e354282e230afdbcacf26af3\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "027fe5e35447eec99b63eeb0d2fb8892aadff9c7a4461adda3466174ba6218f4a4"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "031ad6bc910642bdb39008d57e7a0e58b555c7952f120f9d7f40b67bff30016669"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_multisig_2of3 label=HTLC_1_of_3\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+
+	payload2 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"a19b075f4cc2d1e9d8e8ccd6722228ee0a8931a20da4f20f5d6fe2d1250b8d1b\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"0208b4ff71800339677991916dab228845e27edd269c77e6aeabe4ed92871bb122\",\"0302a269d2da53cd3585e676984615146a60cd2e98547a4dfb89d035091578ab2a\",\"025b8d335f884def4da987ac40bc2d2b9a37e1a763823422fdb56ce560c2710c0d\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "025d2b0908ce56e2c3a114d6618dc2f7dadb7061029a239d890715bff82aa68e57",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"5a91c3e3afe0136fd914fef48c3e0eaccf0c6c4ee98d8ddc640dc049d5ddebf7044f27a1c9eb91103f5de941f9d15b75414e53f935ef8c82a85919b6108e6398\",\"5539cae444b074905f656c3bad9ffa5e92c753b08930e886687cd9ebe1d7b99c488959751b032d6107ca1a952cf9aae3fd8b039ca95b083d07225180d1f67a0f\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"5d1f08bb5655946ed8d519a8a337fca17dfe872e3fbbce6fb978174c3f397637\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"0208b4ff71800339677991916dab228845e27edd269c77e6aeabe4ed92871bb122\",\"0302a269d2da53cd3585e676984615146a60cd2e98547a4dfb89d035091578ab2a\",\"025b8d335f884def4da987ac40bc2d2b9a37e1a763823422fdb56ce560c2710c0d\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "038effbd57c6b62aa0dbcf51340e7d105d95787f8145910d2b31c3e8cf16f2f312",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"a12e5cad6f34b14f51cb0f7753f9e89e40747fd8745839f8df68fe2fa349ac514c351989feba40c09772a84c6d81b0dc8a4ede1dca451ac2ebb6d23128747fc7\",\"a0b70fe70511c09f966334be675426bc948e583a05e705cadd0b508ea9fcf541881d1e23793383b2e74951add43f74ee4ea386b8fb3c20e456fc7a6d5ea244de\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "027fe5e35447eec99b63eeb0d2fb8892aadff9c7a4461adda3466174ba6218f4a4"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "031ad6bc910642bdb39008d57e7a0e58b555c7952f120f9d7f40b67bff30016669"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_multisig_2of3 label=HTLC_2_of_3\n%s", payload2)
+	proofs2 := decodeProofsFromPayload(t, payload2)
+	err = validateProofsWithLocalValidators(proofs2)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_htlc_receiver_path_after_locktime(t *testing.T) {
+	setCompatUnixTime(t, 1781729948)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"a2b4f3f6bd391e7345a348ee3aa8aaccbcdd8a5d0c3f4ac5c3f8b1c3da6f77ac\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"0272857fd8a6ef5a8b079d29b3a6fcbb745f11331c43c971bbedda1e1d340f1ec1\"],[\"locktime\",\"1781729947\"],[\"refund\",\"0285cdb63410cd2b870d5f8d4fffd282ce1928a064616a54d3574b500cbbd8bcf2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02e202565faef0c0166246622074074a2b8faec9a0c7bc5812d00db195a6338064",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"e28bbe94d2d3a21f31987691b866fae07e819d5a326334bb56f69c620c4e1da3167105055a29c7fcab82de09d49ae84c498e7a2716212b38de43d0e3c10fb5c4\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"b9f6b27b8826d8c590d88c3f7649a4417d48df1cb6cf59a754177e420bcfcc14\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"0272857fd8a6ef5a8b079d29b3a6fcbb745f11331c43c971bbedda1e1d340f1ec1\"],[\"locktime\",\"1781729947\"],[\"refund\",\"0285cdb63410cd2b870d5f8d4fffd282ce1928a064616a54d3574b500cbbd8bcf2\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "03450d144d0592a9025f8dbc21dc60cbca47a14819e503bbfc7823156fd63a0638",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"99e1157c821611d31d8bc29931e06e9118b2c8123c36859be7d6e81f4e1ff018651d193183f9acb5010c43138e36fabf80f8a9c58c209ea39df089e025fc5642\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0392b6892a40433edb6085f3ca4ea608df95c8a0bff683e840eecc2b02452bd601"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "037c9235c67658bc6564d3be8067c41d80bdcfa325dd9df4378a9afc4d1729b8b8"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_receiver_path_after_locktime label=HTLC_receiver_path_after_locktime\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_melt_p2pk_unsigned_fails(t *testing.T) {
+	payload := []byte(`{
+  "quote": "paV3ur3q6w-oWIMlKxP17FVJbAmxnyC1k6M0ghXX",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"407e26770c0889a558a957824681e45870550e13fbfe2724594f64e58870f719\",\"data\":\"038a696fdb339ce5179adaea1d17bc2da45bc8086fdf214d7f315a9ae1acd58670\"}]",
+      "C": "03cd7601903e9eda823b97f7102ab14ab191691dbaf679a2d6688acf19dc2c6edb"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"92fea47e26cd7db5081c615dab3cb35cacfe2742f633343ab484700e74fd770b\",\"data\":\"038a696fdb339ce5179adaea1d17bc2da45bc8086fdf214d7f315a9ae1acd58670\"}]",
+      "C": "023c4b4e12c83a0f80c0a0ac4c39a8886682a04da6d8a5ecdcea4a6a3e7f44cd5a"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_p2pk_unsigned_fails label=melt_P2PK_unsigned\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrNoValidSignatures)
+}
+
+func TestCompatibility_melt_p2pk_signed_succeeds(t *testing.T) {
+	payload := []byte(`{
+  "quote": "yrEtkkW3n4c-w6ybDyGJgHPkHraUiYJvyVBgiP_m",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"879b84468b63c8f2ed989b10b088bb6a7f3fd1fe90aa59c148fd66280d89e4d7\",\"data\":\"03e7174902bbe74572563efcc1043f5cc227d650dafe010188494587bc49499af4\"}]",
+      "C": "039aaa14e8632468521f91dbc64b5193606010b8895e3217fe0882113dfd8bffbd",
+      "witness": "{\"signatures\":[\"454ba85c3c34673473d9161d15229d32c5017e028e0cb6abc3ac9fa22ae28203e5ddb027e87b10656f97dab301c9a5edd438eb38ecb7ac8ae59bbde5d315325b\"]}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"dc36470f5d1e8e852ba343ca0edb589996228cc064333da98f923b824af0358d\",\"data\":\"03e7174902bbe74572563efcc1043f5cc227d650dafe010188494587bc49499af4\"}]",
+      "C": "024f997e517ad975cedf68c7c45f1308562c2e746df62e0a4326d1bdd86683433b",
+      "witness": "{\"signatures\":[\"81b234a5825ba9d5b76f34d9262b8881a06d5ba784868881adb6800e2054c71fa12a6762d5536f0c7f117b500ace84f5e39b956cf2602aae709bb091c355c80b\"]}"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_p2pk_signed_succeeds label=melt_P2PK_signed\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_melt_htlc_preimage_only_no_pubkeys_succeeds(t *testing.T) {
+	payload := []byte(`{
+  "quote": "rDtihu27uvcLbL42BA2ah3RjdKTvHRya7ZEiIUyb",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"5d31e982a84a388a82d96bdc79134391c6ba85b057be5b305a37346710c989b0\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\"}]",
+      "C": "020214b457803af1f84df725348edf6e3260fe2ed0860ba54b57e97e66c6cb4d6a",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\"}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"dafc0f223369c9d763bd520d529abbe8ce4f24f17868d5a7806e2364bbd04e14\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\"}]",
+      "C": "02ca6cfcf30b314798cddbe2428e049f6eef391c60ffcb5b1b6e97ea63608e640e",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\"}"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_htlc_preimage_only_no_pubkeys_succeeds label=melt_HTLC_preimage_only_without_pubkeys\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_melt_htlc_preimage_only_fails(t *testing.T) {
+	payload := []byte(`{
+  "quote": "Jx--4Ceq-OWjthsZqpmH0GZ-JrGPjs2k7lFUe-ki",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"6d5d8971f2c9ab3a0ddaee49f2fb01da6b7ed22082d9d5752f34514a6bcb5d4a\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03d08996e7ef5067e8015620aacd8465cbc698caccad6b1eec210996b54f8028c3\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02fe97423d08585803d18a8b43bc20e35a116f3313749b215909678948ff8f23e2",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\"}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"0b195df2151d659b405cdebba193f7d2bbc20b364d1ad2a1998c431959a955ce\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03d08996e7ef5067e8015620aacd8465cbc698caccad6b1eec210996b54f8028c3\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "03bd51d462ab0a87c4a48e24732ac349fd297afc13cd458c86bf6f1304197ae274",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\"}"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_htlc_preimage_only_fails label=melt_HTLC_preimage_only\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrNoValidSignatures)
+}
+
+func TestCompatibility_melt_htlc_signature_only_fails(t *testing.T) {
+	payload := []byte(`{
+  "quote": "qVb5uKgiVFpevx3KSvuyRcwXPJYFzOqnFjnR_ka3",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"f4a68b90a19d092eeebee054a35aae177eaec3bf0b9c3344090a3b41c8e7b100\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"038a8a894628535baae2fa4241ee7780776a9df595d23a42e838eb14ca5ca6123c\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "031bc38480d7ffdf20dbc58a2cb14cd717435ea3f054f5351bd75e6609c8468a8e",
+      "witness": "{\"signatures\":[\"1e1db8da17201b027e3f52e50f97982ed71a4447abf3402287c264753b763dadda2e2774ddd6cf661a5c47ffcab6eab466bc533957ed3dadc4cc9303902ca48d\"]}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"9516313c6438e11f5e49f74fc6db26ea30efd37f4242af43e387bb0cb7803ad9\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"038a8a894628535baae2fa4241ee7780776a9df595d23a42e838eb14ca5ca6123c\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "03f6dbe0db084fd0d600d8a3537b7986074e72ef979b6bbad0c8c1495a8971781c",
+      "witness": "{\"signatures\":[\"a72171150fedafb6fba495e5ce3ab55c6a0e5080fbf2ae8fce7823fcd9a02219ea897b0a16a17082f5512341cd69a0f480dd91030d8d16b3377f308bb23179d0\"]}"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_htlc_signature_only_fails label=melt_HTLC_signature_only\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrInvalidPreimage)
+}
+
+func TestCompatibility_melt_htlc_preimage_and_signature_succeeds(t *testing.T) {
+	payload := []byte(`{
+  "quote": "AdDAmAcm2TEuNJW6oa7bA0Ldf3ba4f3XtjW9d0M4",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"982d4ed1d5c94e92ce5c2f1e87f5ff7f8739c0895a399c4a0198b4bb687bf0f3\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"0225f3a0c96ce568d37441742410ebd0c16633a35f6fbcf69e35349daa4c5802ac\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "0234a5e9e501ca281feccc17139717a2cc83fc9ae805da13676efe6b490786fd6e",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"61176c61c9529a5b59e0f2ae9a60f7e533fa835f75f2fd3ee448e270440a9d17fe5b06c02723924074a85ddf8fb4a0d866af78bee5e00c29916e92aedbefd466\"]}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"82d312ff6a00ef608b6002c23515de0bef3e68e58c729e290fd4a9e840b400d2\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"0225f3a0c96ce568d37441742410ebd0c16633a35f6fbcf69e35349daa4c5802ac\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "0369c41e97b7f9a15e430cff2c3a4df51ddd8ef3bd67b944f391c0b9aeb2b39e43",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"ed48339b9baf5864eeb9c4ff4926af492b04502259a28c7928fe5158294b0a1f5921147d7574cae3ca8650de8f0d1299b25e725e9eb09750ed45b3774944825d\"]}"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_htlc_preimage_and_signature_succeeds label=melt_HTLC_valid\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_melt_p2pk_post_locktime_anyone_can_spend(t *testing.T) {
+	setCompatUnixTime(t, 1781727359)
+	payload := []byte(`{
+  "quote": "QVTBsCZEKpelA20IzxOGA4v4my7OyVvsOEpEAYJa",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"47a3c2970c6ac6db4081ba14ee3ec79e2086490be70a2323153f51b9079dcc1e\",\"data\":\"03706095b6e4236cc4fb8895f70c786f2adbdb7825abc70adf302856e3eaa340f2\",\"tags\":[[\"locktime\",\"1781727358\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "0213f206e8b58663207018208902dff179f25d91fc8313619c9404bcc09c9579aa",
+      "witness": "{\"signatures\":[\"54675d1e7dfd61fdaa41f423f7fa67e86bb482c3b7938f8cbf0c9a090316fb944fb426d9557b23d5fc5cd8d0b65d7449a9871dcefaace609ce3b11805ab79fd9\"]}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"6e631a1ead601b59932bdd578f69aea872c9463f8d141e411b0965c90c8ecb09\",\"data\":\"03706095b6e4236cc4fb8895f70c786f2adbdb7825abc70adf302856e3eaa340f2\",\"tags\":[[\"locktime\",\"1781727358\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "03fab2891978cfd2298dcb3362ae45894d4677ceff1cbc9a224a15757726a5eb5a",
+      "witness": "{\"signatures\":[\"51438ba0010dce00f80c56380a73f69eea3e432a54665b0d2ebc25a4f4830c4cecae1572983885ef729e78a4717fa22aa690856f5d94d722f5cd1753cb0368b8\"]}"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_p2pk_post_locktime_anyone_can_spend label=melt_anyone_can_spend_after_locktime\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_melt_p2pk_before_locktime_wrong_key_fails(t *testing.T) {
+	setCompatUnixTime(t, 1813266958)
+	payload := []byte(`{
+  "quote": "LvOsRfgCp2OWwiECuBd_j-JGXV5BqproSJkd3UFq",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"a107687bd545c787cfa983723f5873b7af9b502e718d1f58c776950fcd936a06\",\"data\":\"03209347d1bf6c264170dd14dc43cacb9332f8036d7fc9a70550409e66e9e98f1d\",\"tags\":[[\"locktime\",\"1813266959\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "03228fc280d902466de09cbdd98bcea4c6463c7aa4c93c30eb5b9a30757cceefa4",
+      "witness": "{\"signatures\":[\"9b56f434bfffb282fb8b21e9e1059bd72a340feb43bd6fcc7283a77f4679047da5ae30629f6f83e914e3bb52c31f48b35c8df57d7808f57edfaaf35a5fb542d9\"]}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"fca2b68506f1466d85481c30a45529f23068da00687b9e138c7caa808e95a38e\",\"data\":\"03209347d1bf6c264170dd14dc43cacb9332f8036d7fc9a70550409e66e9e98f1d\",\"tags\":[[\"locktime\",\"1813266959\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "0341d278fbf120c0381ca6f707001367a07cef5a564e82940a3271f125a7c3b48c",
+      "witness": "{\"signatures\":[\"5f10ae9539e8b88481ba66f6612f2127597a155e61cc1032991301bde7186c297620a824c2faee6e4ba58d59dfdc167450df2883950bd90ffa0ea40749065f67\"]}"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_p2pk_before_locktime_wrong_key_fails label=melt_P2PK_wrong_key_before_locktime\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, ErrNoValidSignatures)
+}
+
+func TestCompatibility_melt_p2pk_before_locktime_correct_key_succeeds(t *testing.T) {
+	setCompatUnixTime(t, 1813266958)
+	payload := []byte(`{
+  "quote": "mSMWjcCMjNoxNe7wVU9bbTZMwviE5grQViW57xZu",
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"3f3b2b8c8abf30671f1babfb733fd7e38170545a9ae885a22844775271b58f63\",\"data\":\"03c933f304db7c81453677cb3b1b7765c5cb58a1d91e55896cdc8b423286e0c5c9\",\"tags\":[[\"locktime\",\"1813266959\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "03430201884f0bce2e4ea2e21f080130ca4a78579d99ae79d2b64d609af9f55d6b",
+      "witness": "{\"signatures\":[\"96280720e9e1fa6c104fbac2d1cb94f126866be9ba7fab5cb855294ca2bb921bb7ab8b6e4a31875483e36460b9d90a884156f10a6891ab70e63d6f30804787db\"]}"
+    },
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"42c9d55f9162e37f80695afec30b50e0b15977279ade5ea0d5c9b2f803b0a27d\",\"data\":\"03c933f304db7c81453677cb3b1b7765c5cb58a1d91e55896cdc8b423286e0c5c9\",\"tags\":[[\"locktime\",\"1813266959\"],[\"sigflag\",\"SIG_INPUTS\"]]}]",
+      "C": "02d85c657cdd7bb0f67eacc5bd290188fc6d63511558b88770cfec2cde44564b73",
+      "witness": "{\"signatures\":[\"bbe7ebc72b90b5b32ae797b3f2df5ad166233feb4b894ec4fc8b85758fe8adc63741b21545bd4ff3bba14d51d56031920d318f1d46643016fcfa5c6b54cdef93\"]}"
+    }
+  ],
+  "outputs": null,
+  "prefer_async": false
+}
+`)
+	t.Logf("scenario=melt_p2pk_before_locktime_correct_key_succeeds label=melt_P2PK_correct_key_before_locktime\n%s", payload)
+	proofs1 := decodeProofsFromPayload(t, payload)
+	err := validateProofsWithLocalValidators(proofs1)
+	assertCompatError(t, err, nil)
+}

--- a/api/cashu/compat_swap_sigall_scenarios_test.go
+++ b/api/cashu/compat_swap_sigall_scenarios_test.go
@@ -1,0 +1,1387 @@
+package cashu
+
+import "testing"
+
+func TestCompatibility_p2pk_sigall_requires_transaction_signature(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"0b84ffccbc210c94faaf1f9833862f8e9d463fc9c4900cf652cc6d4a7bac38d0\",\"data\":\"02b8aa2d8a880fbd299ea68d851b7fecdeac6838cc6f177662a4aebc5a74e97c4d\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0321a4889137cd0b35371ea2c1cf1cd38b96dbf264f3cc3ca44c50a1c3a241fe30"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"ee0afdb2f89a2866c7517cc5d1ea56295788636425a2def0b3933b1e62c88226\",\"data\":\"02b8aa2d8a880fbd299ea68d851b7fecdeac6838cc6f177662a4aebc5a74e97c4d\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02f7d02aa63d9fd9e09ea41ba47eeb3448cb13bf40a9bbfaf2e63012531dd68d7c"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03c7991f6d20c0870bee631fd27b9cbae50805a2ead1778f81370f40681a5da191"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "030a5640e58375dedcc5a823cb1c1889b0607812dba2a63764c70e62dd1f60653c"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_requires_transaction_signature label=SIG_ALL_unsigned\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+}
+
+func TestCompatibility_p2pk_sigall_sig_inputs_fail(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"d07ef0283f7590b43df4e6c54dc905dde623131cc70dc4d4c26cd3c6da5bbba5\",\"data\":\"03c3a351100fe61c94772fdaabf4086f178e85e95687e29692d49a0c69e5c1a4a3\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "020defd2e67ae5c1ad964cb0cb373767cc21142e8af655fb1d00afc945610d3d16",
+      "witness": "{\"signatures\":[\"1d0001f1db27ec80612fb1a25d6d04f00b5b95c6b32bcd508d8142e07209b8abae4e116d94a26726d9a2047275390db88a832ed68cba24cff3cd17752eb9cafb\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"c6fbdc5fa0dc1b6dcfdafab86e946b5c554659da8b38eda542ae3c8815d71b3d\",\"data\":\"03c3a351100fe61c94772fdaabf4086f178e85e95687e29692d49a0c69e5c1a4a3\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0286b38d72ed75414b86f702d6910167d1d229b48789bba73191fa765c4b84eb1e",
+      "witness": "{\"signatures\":[\"9baadd6c3829cf80de63186b2fc459b7d089b3bf073083c7dc664866a44ad0c13dbbfe08f06fb8371e794d94708a7d4e93d070636090218a09dc7d930c4839a3\"]}"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03fb50f7e8db4a7569816d65fcc74425e4604603b3a585ad504edcdce50a43865f"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "031bec8cb714c91e8072b20fe31a638eab84a128a5d020f5afe144483426bc0bc8"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_sig_inputs_fail label=SIG_INPUTS_used_for_SIG_ALL\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+}
+
+func TestCompatibility_p2pk_sigall_multisig_2of3(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"c19d54cefdf20e2d013732c5c6fed2ef66fc502718022ebef575b523c6b55803\",\"data\":\"03ee71b61444bb7a89f7720d72fa81649a3d054023b9a547931fbf0b0156c02c77\",\"tags\":[[\"pubkeys\",\"028d3a993f0cbdd586170fd7dc698de37ac14c39898245af24176641518b746135\",\"02ffa5b2900b34e0f7c7f3eca2bec0a317c774559c606ddb4eccb4ec14d090f844\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "027b243e337679a9bec22544c094d9d5de187ccfa1474cd5e6dcbdadccc55f3131",
+      "witness": "{\"signatures\":[\"1ae8a8e39f7f2bd7184e1ba3c30a4192a96fe4fba58fa63799e415a97903869b4882a523e7647b3147cbf4596b58ffd3495debcfcbf72d5e742462907a069b25\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"b79b8fad9272aabbe6b34e4825642fa94cf3caeaca871c06357dc9e0ed8a3adb\",\"data\":\"03ee71b61444bb7a89f7720d72fa81649a3d054023b9a547931fbf0b0156c02c77\",\"tags\":[[\"pubkeys\",\"028d3a993f0cbdd586170fd7dc698de37ac14c39898245af24176641518b746135\",\"02ffa5b2900b34e0f7c7f3eca2bec0a317c774559c606ddb4eccb4ec14d090f844\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03dd471ba8a4fa8f18ec01264d6287337225a996b02a628512d07a12454a977bb6"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03d39205d1681e9fd8ca2e977be92dd0f806908faa2b4815ad02e702e79207048f"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "021e41cccaaa0760bd6245bb2c616e5eba1f9a4ad4917c17e107d7e70947ba2521"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_multisig_2of3 label=SIG_ALL_1_of_3\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+
+	payload2 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"c19d54cefdf20e2d013732c5c6fed2ef66fc502718022ebef575b523c6b55803\",\"data\":\"03ee71b61444bb7a89f7720d72fa81649a3d054023b9a547931fbf0b0156c02c77\",\"tags\":[[\"pubkeys\",\"028d3a993f0cbdd586170fd7dc698de37ac14c39898245af24176641518b746135\",\"02ffa5b2900b34e0f7c7f3eca2bec0a317c774559c606ddb4eccb4ec14d090f844\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "027b243e337679a9bec22544c094d9d5de187ccfa1474cd5e6dcbdadccc55f3131",
+      "witness": "{\"signatures\":[\"23427aa16878008e8366d21a53d4e4c8b2f54ea7deafaac5adb4679eabef3284f24577b4c91d259711037682f9cdd20d363b51286558602b659f699bf72e0cbf\",\"2f1e81e8bca404c8a9f0df3f7ee95bf6a3a636f8bfa5a4eeebe2b29f2344744f87d0b1aa1aee7819f8b40973a7256c900de3185f55c6f9226583e6f2153c0a65\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"b79b8fad9272aabbe6b34e4825642fa94cf3caeaca871c06357dc9e0ed8a3adb\",\"data\":\"03ee71b61444bb7a89f7720d72fa81649a3d054023b9a547931fbf0b0156c02c77\",\"tags\":[[\"pubkeys\",\"028d3a993f0cbdd586170fd7dc698de37ac14c39898245af24176641518b746135\",\"02ffa5b2900b34e0f7c7f3eca2bec0a317c774559c606ddb4eccb4ec14d090f844\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03dd471ba8a4fa8f18ec01264d6287337225a996b02a628512d07a12454a977bb6"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03d39205d1681e9fd8ca2e977be92dd0f806908faa2b4815ad02e702e79207048f"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "021e41cccaaa0760bd6245bb2c616e5eba1f9a4ad4917c17e107d7e70947ba2521"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_multisig_2of3 label=SIG_ALL_invalid_signers\n%s", payload2)
+	request2 := decodeSwapRequest(t, payload2)
+	err = validateSwapRequestForCompat(request2)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+
+	payload3 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"c19d54cefdf20e2d013732c5c6fed2ef66fc502718022ebef575b523c6b55803\",\"data\":\"03ee71b61444bb7a89f7720d72fa81649a3d054023b9a547931fbf0b0156c02c77\",\"tags\":[[\"pubkeys\",\"028d3a993f0cbdd586170fd7dc698de37ac14c39898245af24176641518b746135\",\"02ffa5b2900b34e0f7c7f3eca2bec0a317c774559c606ddb4eccb4ec14d090f844\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "027b243e337679a9bec22544c094d9d5de187ccfa1474cd5e6dcbdadccc55f3131",
+      "witness": "{\"signatures\":[\"c2bd0821a7ddf4d94b15f6b33446a4e45b86ab77c5b899ddfa4a5afc51e43964039ade903918fd64803bf0b44f18ea0e69c4311cee625f4043608e4a52150a09\",\"5688ebbd137f8ca28587974ecd98ce901cce7a90f33c439a630627e5c29872b0c0ace814ce1d13426a4f57614abeb6aa9cf4b73edcd50a70b9df417da806bc42\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"b79b8fad9272aabbe6b34e4825642fa94cf3caeaca871c06357dc9e0ed8a3adb\",\"data\":\"03ee71b61444bb7a89f7720d72fa81649a3d054023b9a547931fbf0b0156c02c77\",\"tags\":[[\"pubkeys\",\"028d3a993f0cbdd586170fd7dc698de37ac14c39898245af24176641518b746135\",\"02ffa5b2900b34e0f7c7f3eca2bec0a317c774559c606ddb4eccb4ec14d090f844\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03dd471ba8a4fa8f18ec01264d6287337225a996b02a628512d07a12454a977bb6"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03d39205d1681e9fd8ca2e977be92dd0f806908faa2b4815ad02e702e79207048f"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "021e41cccaaa0760bd6245bb2c616e5eba1f9a4ad4917c17e107d7e70947ba2521"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_multisig_2of3 label=SIG_ALL_valid_2_of_3\n%s", payload3)
+	request3 := decodeSwapRequest(t, payload3)
+	err = validateSwapRequestForCompat(request3)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_sigall_wrong_signer_fails(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"40557eda1581481fac1e4fd07722f27fc9980761caf387ddcc2eaaf3978a952a\",\"data\":\"029a8237638808d73b361c0bc5010be4ca02e67e7210021fb7555e8ae7f215b9d3\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0319951f5cb1950966729ce123cefd8eefce723a055bd84f4fa006265aef18c985",
+      "witness": "{\"signatures\":[\"ad85e57ccaa9b04e06cd7cc1b8b15477d9eb3ef584ac83b1d06f6802a5be555329a3275fad9c646d50cb952382025c1636b87494f43f0dda140a9e759ed262bc\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"79d42561e0d65086ee28ad7f91af8f7748c6d945a26d48bdf91d1b569be22f1f\",\"data\":\"029a8237638808d73b361c0bc5010be4ca02e67e7210021fb7555e8ae7f215b9d3\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03a70fae4f2c2e3e3cc3f0c8717537abf6c9f1a20f6279228c2168e2fbcdc01a46"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "039530b502696da451289a8ffb33f2788a23513affd217265628b0c7ba45cbb9a7"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03d7703f2b0878922e07ccfabac3c519bc4bde49cb5efcd0ca9c03d9e70761530d"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_wrong_signer_fails label=SIG_ALL_wrong_signer\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+}
+
+func TestCompatibility_p2pk_sigall_duplicate_signatures_fail(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"e71f64aae8a9a774626b43319a6a793d0873aa7e63025c22d0622880e59e9417\",\"data\":\"0358856eec4c6506c03f5eae8ea32f85e5cba49c307eaa43b0071d155fa2961c1f\",\"tags\":[[\"pubkeys\",\"037f816b11e43033b84b0585cfb53bbe7f95e330d69f07d6a04e9b5b624ba07414\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "022e9ad8ef67429b139a7559b40020a4fec8cb25c96ae22d7e6dc5a18547dba0e6",
+      "witness": "{\"signatures\":[\"bf88e479f45fbfbbd5e37b95ef9b0bbee0997ca8c346ac37cbf3f7bad9fe4bb0a3f7953550efc430f6c6abc586070d36666635158c40e60a5b727a0126305ffb\",\"f435fe7a77c960dc784860fc5575316b27e4f2a175d46d96fe41ab5362a05b458af1ef4522e70cf139ee6975f7190f18bee639698ffd7f0fd66137c69351cbaf\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"0bd04a3f88f2b118733436a308baf3fd1ff80886f5b5a242d7ed4dc239d39d68\",\"data\":\"0358856eec4c6506c03f5eae8ea32f85e5cba49c307eaa43b0071d155fa2961c1f\",\"tags\":[[\"pubkeys\",\"037f816b11e43033b84b0585cfb53bbe7f95e330d69f07d6a04e9b5b624ba07414\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03bbd40753984e46572e1f4e47f58aa01e790eedbde302c147d21d4b8708c31478"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02c6545b40b0bfe59ae3c62160cf0ebfc13626edb3132fbca7b6c594b27a7b2b01"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "039dcffc4766685b191f9dec781b0fc2ae1ab2acb8ab03a401e65d1f4f0680423a"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_duplicate_signatures_fail label=SIG_ALL_duplicate_signatures\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+}
+
+func TestCompatibility_p2pk_sigall_locktime_before_expiry_primary_only(t *testing.T) {
+	setCompatUnixTime(t, 1781734548)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"8f89150de799e2436b0c8822800a4759677108a5486bd67837e4a6daf87bdd23\",\"data\":\"03ee40ffd61673753ee3ce619981c9868f78e928426f4a7f9d6dc8fff32c832419\",\"tags\":[[\"locktime\",\"1781734549\"],[\"refund\",\"03f02a2a968ced0c3f00b6951e10a2c135b3a2b125e1907a4fa3bdb3bc7ce2f61f\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "027ce07efb89fbe53237c571048d85fdb9ea42fa2c2669345989874c715cc6e233",
+      "witness": "{\"signatures\":[\"dbdea8fac937f38fd6558687b14026e01876c079f90464e759de25b9247cff8c4e012ebbcf40c8982dee402345849f340b8038f29ce5c235250c7bd04276c8a0\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"79eec14991f8f5ba11672831ad401a87764fe0ded6696011e98d4da446a6f5cc\",\"data\":\"03ee40ffd61673753ee3ce619981c9868f78e928426f4a7f9d6dc8fff32c832419\",\"tags\":[[\"locktime\",\"1781734549\"],[\"refund\",\"03f02a2a968ced0c3f00b6951e10a2c135b3a2b125e1907a4fa3bdb3bc7ce2f61f\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02c8a13ebd0ed8c82a5382859143a5e3cc1161497fe07df4998cfdbcd7c1d88f32"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0216bd853d7891d815051b64850118da265e5e555eed3f573a88f3967b6ed323b5"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0242f71bf738e64a652418e1b2e8a5a5739ef735ae6175dac193ad0a07ad0c8002"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_locktime_before_expiry_primary_only label=SIG_ALL_refund_before_locktime\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+
+	payload2 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"8f89150de799e2436b0c8822800a4759677108a5486bd67837e4a6daf87bdd23\",\"data\":\"03ee40ffd61673753ee3ce619981c9868f78e928426f4a7f9d6dc8fff32c832419\",\"tags\":[[\"locktime\",\"1781734549\"],[\"refund\",\"03f02a2a968ced0c3f00b6951e10a2c135b3a2b125e1907a4fa3bdb3bc7ce2f61f\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "027ce07efb89fbe53237c571048d85fdb9ea42fa2c2669345989874c715cc6e233",
+      "witness": "{\"signatures\":[\"6a01814b84abacf4a9e2d1f2a646a34fd2b526bab00a7073f4fd8409d28bbc7e817a32583b1649530f732366f8e41323e2ae170f5211447605ecfea72461c7d0\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"79eec14991f8f5ba11672831ad401a87764fe0ded6696011e98d4da446a6f5cc\",\"data\":\"03ee40ffd61673753ee3ce619981c9868f78e928426f4a7f9d6dc8fff32c832419\",\"tags\":[[\"locktime\",\"1781734549\"],[\"refund\",\"03f02a2a968ced0c3f00b6951e10a2c135b3a2b125e1907a4fa3bdb3bc7ce2f61f\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02c8a13ebd0ed8c82a5382859143a5e3cc1161497fe07df4998cfdbcd7c1d88f32"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0216bd853d7891d815051b64850118da265e5e555eed3f573a88f3967b6ed323b5"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0242f71bf738e64a652418e1b2e8a5a5739ef735ae6175dac193ad0a07ad0c8002"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_locktime_before_expiry_primary_only label=SIG_ALL_primary_before_locktime\n%s", payload2)
+	request2 := decodeSwapRequest(t, payload2)
+	err = validateSwapRequestForCompat(request2)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_sigall_locktime_after_expiry_primary_still_works(t *testing.T) {
+	setCompatUnixTime(t, 1781727350)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"5d11cfc203664bbb5f23a5fb1e7c7ff0386237e9f6e128f0c482cfbd84d85585\",\"data\":\"0229c56568371c2952c5cd84fde6d68489994e8131a71b4b0dea8875f6096ba8ba\",\"tags\":[[\"locktime\",\"1781727349\"],[\"refund\",\"02c623a82851155646397fbfbabbf825440eea7227470dee3de3becea0347835be\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "039b8eb94e0cb7fad5cb35f9f26a86c728922f81e5828957d81a26ca1ed2f23466",
+      "witness": "{\"signatures\":[\"b14c48f5b4f87ab5c8a07eaabd2c8ff539b7cb3c2adfd15583cc13183c5a7b48567e0704e7e6c135f3e00a1cacb03753dca1e4a96342c6c3cd2dc5df3e761165\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"819d7e2fdd5fedbd68384b36061370a70a2f515a8bcb282b0107847efab7ecc5\",\"data\":\"0229c56568371c2952c5cd84fde6d68489994e8131a71b4b0dea8875f6096ba8ba\",\"tags\":[[\"locktime\",\"1781727349\"],[\"refund\",\"02c623a82851155646397fbfbabbf825440eea7227470dee3de3becea0347835be\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02bd74904537b02d2c8d11b2312fae85e03fed3d65ac27c24ec6ec81f36422f7b9"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "023ef6cdb9ad3e9f3cc62ffbb25d84b743f63ab9180b1f524e98d20bc65711039c"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0339461cced31998e92b6829688ae801b56092551d59556e8836049184682d5d26"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_locktime_after_expiry_primary_still_works label=SIG_ALL_primary_after_locktime\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_sigall_locktime_after_expiry_no_refund_anyone_can_spend(t *testing.T) {
+	setCompatUnixTime(t, 1781727350)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"634bf4e1f0852f4503d2cb805735b4df9fe4b749499a4e8220af6bf4d11dd637\",\"data\":\"0289f1e8c147f19b8ba7ca86eb9d161ed9b010a8bf41fe4173f31cdc5f05f2639f\",\"tags\":[[\"locktime\",\"1781727349\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0391a0a87facf432b00ae1586f24fda4f4602ce485857f53f0f47fb0896660ddbf"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"0271fb80f85bddcf20092cc9af3374ee4e56be4a4476dbde05d2eb39c6215c9c\",\"data\":\"0289f1e8c147f19b8ba7ca86eb9d161ed9b010a8bf41fe4173f31cdc5f05f2639f\",\"tags\":[[\"locktime\",\"1781727349\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02457468ed742487053feb9edc67261ce836196be22e979c14237fcc468b0d6137"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "036565ff8105f6195b72272861d7dc9cc7324f543cc296b53e578e4e59d7a97ce7"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02dc8a0fc020d11df38fd4f62dcb281725b5cdf12d750246d24ed816bcc8e9c120"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_locktime_after_expiry_no_refund_anyone_can_spend label=SIG_ALL_anyone_can_spend\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_sigall_multisig_locktime_primary_still_works(t *testing.T) {
+	setCompatUnixTime(t, 1781730851)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"2ed0b188fa18b97d905fd324865aaf8b3f959cc58f03aca8c2a85d4753d84eb3\",\"data\":\"03884b6a5a12daf991827cd24eb96c954b2eddbeb951855348cfd2ad0aa59df340\",\"tags\":[[\"pubkeys\",\"024252fdfe22388fe34ab371f3fd38f0cb7d8ff54c156a7ad616778fe87ac7c822\",\"020b1174ad6dbc315346eff562270f4dc25d567f47a39301ac83ac4a7edbbcddfa\"],[\"locktime\",\"1781730850\"],[\"n_sigs\",\"2\"],[\"refund\",\"020cfcc9f1618b40f1a0e0a439e6642341f30075752d4dc852bbcda72e70fb1d69\",\"02d108473d9230cd31b0cc038a9c46f51f6472e6c14303a8b0df4b033b3eca3d4e\"],[\"n_sigs_refund\",\"1\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "037a004658471759019b365402c90491880988ecbcf86ab4f9c8dc83ae98ff0fa8",
+      "witness": "{\"signatures\":[\"78c235368d65b8f59c9e95fec736a4f08ad690a8eb35874d41340eb2fb2789877c8f02eac99b03cb2505651d0621ca908dcd095276b59927872023ae9ac0e17e\",\"0f84ccd2df7b5725ee3e841173053cdf32d610cabea88b20d67985e28de04fd95d60a9af47793c202372e91794e8b0934fe3b8f30663f9e56ac61efb58e7dd6f\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"bd5aa9a6e2eb8108313b3a535a58b3a2dee60f552d61d2ddb6cf8df3add4014f\",\"data\":\"03884b6a5a12daf991827cd24eb96c954b2eddbeb951855348cfd2ad0aa59df340\",\"tags\":[[\"pubkeys\",\"024252fdfe22388fe34ab371f3fd38f0cb7d8ff54c156a7ad616778fe87ac7c822\",\"020b1174ad6dbc315346eff562270f4dc25d567f47a39301ac83ac4a7edbbcddfa\"],[\"locktime\",\"1781730850\"],[\"n_sigs\",\"2\"],[\"refund\",\"020cfcc9f1618b40f1a0e0a439e6642341f30075752d4dc852bbcda72e70fb1d69\",\"02d108473d9230cd31b0cc038a9c46f51f6472e6c14303a8b0df4b033b3eca3d4e\"],[\"n_sigs_refund\",\"1\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "037264437b740b689dcc4ab11be7ecac997091597d6438a12679dca5ed9e1aa2d5"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "034a3614c8fc506fca88977cd4bb8cc16431e84e33cdbe8814dea4028dec993422"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "020e05b19b8940cf66ce1eb135458ad0e537352feaa28839b6a3a332e14adc7bde"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_multisig_locktime_primary_still_works label=SIG_ALL_primary_multisig_after_locktime\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_sigall_mixed_proofs_different_data_fail(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"06a9de58f7fcd8ee8546d67a54463549157eb424557d603d6bd3cfca95f381d8\",\"data\":\"03ec04a2e43eb1b04fa7ffef934127848c6902b7e0cedfaa4f8d14106b51f3b6ce\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03d6db559400df5f339e31cba4020dd3de7f19443e5b33f5ced37002d6d44ed608",
+      "witness": "{\"signatures\":[\"4863e32148cea88e33209b89c5417b641d21485556b59e055038f56424f5cb59903904310ea3f10380dc60294e52698301095fab3e65ebacf6506860f3173a33\",\"d0a164947fcfe6235bad78b34eb81a7f759fa33b2fd85e092e69963b728902637756ce926e20ee8072e955baea84955051dc60731e947cd760fa8c5d48dd109c\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"dab10bd128821263917eff6cd63707b3fba6fa67d328c2dc0c5ac79f342051fd\",\"data\":\"03ec04a2e43eb1b04fa7ffef934127848c6902b7e0cedfaa4f8d14106b51f3b6ce\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0245b0ab8f0a08bff16567848e071ac2830b27776f2e7c9634c7b6a74999c77daf"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"9135358de863443a8068a72fdda2fd197b362e756f4f490493d84e534e4af682\",\"data\":\"03c9971859b5232653872206d74cd4d54dd28b27a6405fb5e0a550e5a41fc6f4ab\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "029c59673bad837ee7edb97e19775b07e5d03c650c4ed2b09a4307becb1a5c44fd"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"ee8f433412ac48137e357586a0c0938a95a9dfc8029f80e9fee6d4dd567ef68a\",\"data\":\"03c9971859b5232653872206d74cd4d54dd28b27a6405fb5e0a550e5a41fc6f4ab\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0233d72e2fc7395c0889fe90b940de2a14bc42676e34944365e43abff9553c3336"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "037834b6b659fc4e90351f690f20f51c0ffbc9810962ad832b8418afda9fb7df59"
+    },
+    {
+      "amount": 16,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02adbeb26e470f53b4e2bb6e98a99b4f6f005998212ab46e0dfb4e64e17171f23a"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_mixed_proofs_different_data_fail label=mixed_SIG_ALL_data\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrInvalidSpendCondition)
+
+	payload2 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"06a9de58f7fcd8ee8546d67a54463549157eb424557d603d6bd3cfca95f381d8\",\"data\":\"03ec04a2e43eb1b04fa7ffef934127848c6902b7e0cedfaa4f8d14106b51f3b6ce\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03d6db559400df5f339e31cba4020dd3de7f19443e5b33f5ced37002d6d44ed608",
+      "witness": "{\"signatures\":[\"8ecc79c17d3dcc67d5513b1f83e9b0a89f78630620cde1907990e6ab237644dccabbb11ee75ad7e96db3330ffbcec022c19e715f56d35edbc62d91b71e2c085f\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"dab10bd128821263917eff6cd63707b3fba6fa67d328c2dc0c5ac79f342051fd\",\"data\":\"03ec04a2e43eb1b04fa7ffef934127848c6902b7e0cedfaa4f8d14106b51f3b6ce\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0245b0ab8f0a08bff16567848e071ac2830b27776f2e7c9634c7b6a74999c77daf"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0328a16feb6c5dcaa14ef50a27431d04c1ffa091cb3096ec6494e51c2b0519b82f"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02ad16191490cedf10897b8e0f8e18e62c9048d09b7438ae13f97cdaffd2f60e27"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_mixed_proofs_different_data_fail label=alice_only_SIG_ALL\n%s", payload2)
+	request2 := decodeSwapRequest(t, payload2)
+	err = validateSwapRequestForCompat(request2)
+	assertCompatError(t, err, nil)
+
+	payload3 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"9135358de863443a8068a72fdda2fd197b362e756f4f490493d84e534e4af682\",\"data\":\"03c9971859b5232653872206d74cd4d54dd28b27a6405fb5e0a550e5a41fc6f4ab\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "029c59673bad837ee7edb97e19775b07e5d03c650c4ed2b09a4307becb1a5c44fd",
+      "witness": "{\"signatures\":[\"d9708e8bad2f1ec93ae8ae98b55c98a86105b5d16de42345eee89536e978a3707b9f26ea2a0932fdc329b64cb5daacfc290beafc43a10918e30d44b75f81e9b3\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"ee8f433412ac48137e357586a0c0938a95a9dfc8029f80e9fee6d4dd567ef68a\",\"data\":\"03c9971859b5232653872206d74cd4d54dd28b27a6405fb5e0a550e5a41fc6f4ab\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0233d72e2fc7395c0889fe90b940de2a14bc42676e34944365e43abff9553c3336"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03cfdbab2906509c75b5a2a0ac1f263423d9c5030434cf5662faa49a215c3a3c78"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03d9036ac2fd7f8f1efd23c2d33755070ab1411c4c452bed6d5317b2b7162cc7f7"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_mixed_proofs_different_data_fail label=bob_only_SIG_ALL\n%s", payload3)
+	request3 := decodeSwapRequest(t, payload3)
+	err = validateSwapRequestForCompat(request3)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_sigall_mixed_proofs_different_kind_fail(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"560380512b3dd54ae46db4da620d0fa8649beeb3825dbae566a545e8df34c587\",\"data\":\"027b59d551f5eb1e00ef4a7514887580b1f56bde6c855c39b00bc4e5ce9ea08bbf\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0231c19bceb658216c8005ccee8e9186753298274776142df534c62bdd16bd1af4"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"e6e308471380ab470b90ac2daaa268a8e780015aa785fa469735c34128414215\",\"data\":\"027b59d551f5eb1e00ef4a7514887580b1f56bde6c855c39b00bc4e5ce9ea08bbf\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "023bf845ad3d41a228892d2a568eb10e61aa4b2a0e274b4cf817c714ab9cea943f"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"56ebb5a28fb3bfdadf02e4c18e74fff0fa199dac7ca254a7f47a8a32bdd08741\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"027b59d551f5eb1e00ef4a7514887580b1f56bde6c855c39b00bc4e5ce9ea08bbf\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "039eedb4a37432e258bbb8f7ede0bb373bba37b083a4b8a003209d551047e7d018"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"b91bd907656a415fee61d94906a6fe038c892f2e0b99423ffa6765864bf041c2\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"027b59d551f5eb1e00ef4a7514887580b1f56bde6c855c39b00bc4e5ce9ea08bbf\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03f6a315c692f958ef056ec484923a49a21f82f627af8a37f71a2be967db6ac33c"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03d2712c843fde26810e58872b74b60d4894d37e58f65d0052ee7c23b9700b9bdb"
+    },
+    {
+      "amount": 16,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03221cc475222d69285b47d4dd98ec578b0d9d0a7e11a28ef325a5c3362de035d6"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_mixed_proofs_different_kind_fail label=mixed_SIG_ALL_kind\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrInvalidSpendCondition)
+
+	payload2 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"560380512b3dd54ae46db4da620d0fa8649beeb3825dbae566a545e8df34c587\",\"data\":\"027b59d551f5eb1e00ef4a7514887580b1f56bde6c855c39b00bc4e5ce9ea08bbf\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0231c19bceb658216c8005ccee8e9186753298274776142df534c62bdd16bd1af4",
+      "witness": "{\"signatures\":[\"c5e4a1ec60d81b49e461337faedade95912e2c671ae11804f0d3b9983897f32d7a1d7b3d69ea676226bfa65c01f688367d4436c1327bcc093d9cf97106ce81db\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"e6e308471380ab470b90ac2daaa268a8e780015aa785fa469735c34128414215\",\"data\":\"027b59d551f5eb1e00ef4a7514887580b1f56bde6c855c39b00bc4e5ce9ea08bbf\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "023bf845ad3d41a228892d2a568eb10e61aa4b2a0e274b4cf817c714ab9cea943f"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "036893a596f36f3a6b8e36aeddbf31c6dfed1de2846910817464a73d227d9fb21d"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0387a0bc0853d4b3e36802e18d95c7c16f8ab73d9eec622e4e4edc0df6b73ec641"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_mixed_proofs_different_kind_fail label=p2pk_only_mixed_kind_control\n%s", payload2)
+	request2 := decodeSwapRequest(t, payload2)
+	err = validateSwapRequestForCompat(request2)
+	assertCompatError(t, err, nil)
+
+	payload3 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"56ebb5a28fb3bfdadf02e4c18e74fff0fa199dac7ca254a7f47a8a32bdd08741\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"027b59d551f5eb1e00ef4a7514887580b1f56bde6c855c39b00bc4e5ce9ea08bbf\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "039eedb4a37432e258bbb8f7ede0bb373bba37b083a4b8a003209d551047e7d018",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"1da9b115b99d33df5a7effddf459f7da02eab4cb5f1b71eeed8a1c02c0ca47c257ae4612f30148e6430774faa1199683fa730b379e1b6f8020d1f030c02a3eda\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"b91bd907656a415fee61d94906a6fe038c892f2e0b99423ffa6765864bf041c2\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"027b59d551f5eb1e00ef4a7514887580b1f56bde6c855c39b00bc4e5ce9ea08bbf\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03f6a315c692f958ef056ec484923a49a21f82f627af8a37f71a2be967db6ac33c"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "035c0a7256bf3757cf7708cf6b1ad36695c05bc992a5523b18b0ddb47cdcafe405"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02c096dee654be0e9dd78be256515292448e2e81c1da659411eee6709e721aa87d"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_mixed_proofs_different_kind_fail label=htlc_only_mixed_kind_control\n%s", payload3)
+	request3 := decodeSwapRequest(t, payload3)
+	err = validateSwapRequestForCompat(request3)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_sigall_mixed_proofs_different_tags_fail(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"2b492c8f60b53f52f6e4ed1a5baec7611d715774d1fb884d6564e6c4215f5323\",\"data\":\"0321f46ec408b929ada27a5b340c6e77dff8b5394b437d3ea586081d06a923c596\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0324d903f5545cd0287d410a0106ff755feeb35a484aaa01fe49b37f3987cc3497"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"6d84789b09e0e4c55e08f44e76622e07ddb5e2e30cc03109ac38451db4cf47ec\",\"data\":\"0321f46ec408b929ada27a5b340c6e77dff8b5394b437d3ea586081d06a923c596\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "025434b4e951bd055225ea9b84480a160ba4ba645bd2dd639195dca698ce8bd487"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"f1dbb8647c56939bea627277d610cdc6305b0b0c3f75d233f52fd7c2bad6650b\",\"data\":\"0321f46ec408b929ada27a5b340c6e77dff8b5394b437d3ea586081d06a923c596\",\"tags\":[[\"locktime\",\"1781734551\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02ee0e12f91ce175d3e1aa99f013f979e26a8fe6268aff147c3c95868c86e00ac4"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"bc0d00d6aebe5448e3ae9539e788690992ffa2ad7632ac52afc4e3f431c55a01\",\"data\":\"0321f46ec408b929ada27a5b340c6e77dff8b5394b437d3ea586081d06a923c596\",\"tags\":[[\"locktime\",\"1781734551\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03e63a97dc660aca4f2c3e4fff9d8638631579971297b26a171dbdd2777c74e5ce"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 4,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "025ed67222fbfb4eb546031d7dec507d62452be24adff1cf4c6bd928a79fffc95a"
+    },
+    {
+      "amount": 16,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "032c84d13452b6613d1f01ea41168a1e1eb909a03bbf795fe23c2c8c6bb854af17"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_mixed_proofs_different_tags_fail label=mixed_SIG_ALL_tags\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrInvalidSpendCondition)
+
+	payload2 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"2b492c8f60b53f52f6e4ed1a5baec7611d715774d1fb884d6564e6c4215f5323\",\"data\":\"0321f46ec408b929ada27a5b340c6e77dff8b5394b437d3ea586081d06a923c596\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0324d903f5545cd0287d410a0106ff755feeb35a484aaa01fe49b37f3987cc3497",
+      "witness": "{\"signatures\":[\"aa9a645f491b48d815e909ea81e0a4b964c9704d87fe3e893a09ffcae1e80742dd5187afbe5d7c312744ddd427cfaf3fe55b558e23686f716f4ce007a45185ed\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"6d84789b09e0e4c55e08f44e76622e07ddb5e2e30cc03109ac38451db4cf47ec\",\"data\":\"0321f46ec408b929ada27a5b340c6e77dff8b5394b437d3ea586081d06a923c596\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "025434b4e951bd055225ea9b84480a160ba4ba645bd2dd639195dca698ce8bd487"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0296453f65e431f252630dfd9f76f429e49b48867826b7be2204d6b1b2db11608e"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02070ec51d9bfa1115952af0673dc88da443109d4c4fc58cdd28d0b642ad6f792d"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_mixed_proofs_different_tags_fail label=plain_only_mixed_tags_control\n%s", payload2)
+	request2 := decodeSwapRequest(t, payload2)
+	err = validateSwapRequestForCompat(request2)
+	assertCompatError(t, err, nil)
+
+	payload3 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"f1dbb8647c56939bea627277d610cdc6305b0b0c3f75d233f52fd7c2bad6650b\",\"data\":\"0321f46ec408b929ada27a5b340c6e77dff8b5394b437d3ea586081d06a923c596\",\"tags\":[[\"locktime\",\"1781734551\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02ee0e12f91ce175d3e1aa99f013f979e26a8fe6268aff147c3c95868c86e00ac4",
+      "witness": "{\"signatures\":[\"0e3ef93163fb119ba5dfbefaf488eec4d402e39e87f9e2a9eef7c6c381244ba927ba8ade4ee1c7b395f50f469c410fcdf3a5ef1bcfae2ebd0b72c3e3c2651b01\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"bc0d00d6aebe5448e3ae9539e788690992ffa2ad7632ac52afc4e3f431c55a01\",\"data\":\"0321f46ec408b929ada27a5b340c6e77dff8b5394b437d3ea586081d06a923c596\",\"tags\":[[\"locktime\",\"1781734551\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03e63a97dc660aca4f2c3e4fff9d8638631579971297b26a171dbdd2777c74e5ce"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02db8d54364a0a30688df7d453ff75edcb9f127b5a10cb9406c2c490bbea3f1cef"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03ca686bb13bb2498b927845063c82100cdfc20fac8fe4ca167684c61dc011aa8f"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_mixed_proofs_different_tags_fail label=tagged_only_mixed_tags_control\n%s", payload3)
+	request3 := decodeSwapRequest(t, payload3)
+	err = validateSwapRequestForCompat(request3)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_sigall_multisig_before_locktime(t *testing.T) {
+	setCompatUnixTime(t, 1781734551)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"a4d46f31474c771c24b8960ff0be7375ec99fc3f8d3c3cb41471806e6a21bdea\",\"data\":\"034c7a04055d325baef458d9e96c8a841f054163479588d8ca02dfb3c4f55b3280\",\"tags\":[[\"pubkeys\",\"028021ea7e326460060fbfab59b2133a845e0349890026820685b9f24119b473fb\",\"021c146a591f6f1dc28566a359f12f6f44d65add1504199eb3f815cdd853643f58\"],[\"locktime\",\"1781734552\"],[\"n_sigs\",\"2\"],[\"refund\",\"03b4a173b7bcc7222bd46497a6904a011bd32b970f13965ae94d4324f78f1c40ad\",\"02b7b776067ea33af217848518e5c0f2feb277f25c3f852439e6be031dfa9d9883\"],[\"n_sigs_refund\",\"1\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "028e94729c49fd7e869ce97945886bf1a9da3bfe825bed4e3496bb9d88c1c78663",
+      "witness": "{\"signatures\":[\"0e494530e9b93bad4edba47d282d3ad63ec551e5bb021701b0002571e84775e2ddf6ac99c9b33d1ef658405205b600e4d92e88c44bfb5518090d3358344e6c3a\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"19ae7e7fbf9e4d8081ed6cfa02b0b679775504298d0a0530057eb7edc3d70b3b\",\"data\":\"034c7a04055d325baef458d9e96c8a841f054163479588d8ca02dfb3c4f55b3280\",\"tags\":[[\"pubkeys\",\"028021ea7e326460060fbfab59b2133a845e0349890026820685b9f24119b473fb\",\"021c146a591f6f1dc28566a359f12f6f44d65add1504199eb3f815cdd853643f58\"],[\"locktime\",\"1781734552\"],[\"n_sigs\",\"2\"],[\"refund\",\"03b4a173b7bcc7222bd46497a6904a011bd32b970f13965ae94d4324f78f1c40ad\",\"02b7b776067ea33af217848518e5c0f2feb277f25c3f852439e6be031dfa9d9883\"],[\"n_sigs_refund\",\"1\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "020eca7338e8e868e954608bba623cbd240fdc0de6640d7fe039ea3f6f777f8cf0"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03bdacec658c9c7a1ec7a69dfae21cce0952d8e887613735a8f76f3dcc5dd804eb"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "038acd84fd99773a9f3cf4bd5429e08fb4444b9f1971ed91af642b7056572c5a06"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_multisig_before_locktime label=SIG_ALL_1_of_3_before_locktime\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+
+	payload2 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"a4d46f31474c771c24b8960ff0be7375ec99fc3f8d3c3cb41471806e6a21bdea\",\"data\":\"034c7a04055d325baef458d9e96c8a841f054163479588d8ca02dfb3c4f55b3280\",\"tags\":[[\"pubkeys\",\"028021ea7e326460060fbfab59b2133a845e0349890026820685b9f24119b473fb\",\"021c146a591f6f1dc28566a359f12f6f44d65add1504199eb3f815cdd853643f58\"],[\"locktime\",\"1781734552\"],[\"n_sigs\",\"2\"],[\"refund\",\"03b4a173b7bcc7222bd46497a6904a011bd32b970f13965ae94d4324f78f1c40ad\",\"02b7b776067ea33af217848518e5c0f2feb277f25c3f852439e6be031dfa9d9883\"],[\"n_sigs_refund\",\"1\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "028e94729c49fd7e869ce97945886bf1a9da3bfe825bed4e3496bb9d88c1c78663",
+      "witness": "{\"signatures\":[\"fbc219a5e176d3b968110293b5e4e1366badb1c4303b466627f12abdc036b94172025075ff61e012c2b4e3c982c0eee44a2e2640b492a7e2801d760a4f6c5c81\",\"f3770f2ba2a232882cc132cd3bdb45b237ca5ff3b724801915b7642a13fdc77f6e01ab3c82c3a5336969990e19e781bea2697a0cd8bbd6c79de3587cbc843f35\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"19ae7e7fbf9e4d8081ed6cfa02b0b679775504298d0a0530057eb7edc3d70b3b\",\"data\":\"034c7a04055d325baef458d9e96c8a841f054163479588d8ca02dfb3c4f55b3280\",\"tags\":[[\"pubkeys\",\"028021ea7e326460060fbfab59b2133a845e0349890026820685b9f24119b473fb\",\"021c146a591f6f1dc28566a359f12f6f44d65add1504199eb3f815cdd853643f58\"],[\"locktime\",\"1781734552\"],[\"n_sigs\",\"2\"],[\"refund\",\"03b4a173b7bcc7222bd46497a6904a011bd32b970f13965ae94d4324f78f1c40ad\",\"02b7b776067ea33af217848518e5c0f2feb277f25c3f852439e6be031dfa9d9883\"],[\"n_sigs_refund\",\"1\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "020eca7338e8e868e954608bba623cbd240fdc0de6640d7fe039ea3f6f777f8cf0"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03bdacec658c9c7a1ec7a69dfae21cce0952d8e887613735a8f76f3dcc5dd804eb"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "038acd84fd99773a9f3cf4bd5429e08fb4444b9f1971ed91af642b7056572c5a06"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_multisig_before_locktime label=SIG_ALL_2_of_3_before_locktime\n%s", payload2)
+	request2 := decodeSwapRequest(t, payload2)
+	err = validateSwapRequestForCompat(request2)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_sigall_more_signatures_than_required(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"b546e432689ae743ca621d12b249e73a92906f5ef088873f234264bd7a3270df\",\"data\":\"036c270ddd755c185b9be4768ee3d56fb7ed6d6d084e8d0ec0480b947e6b4ffcec\",\"tags\":[[\"pubkeys\",\"02b81f8f01ffe04467ffa6b109c0da9132dcff645f7c19110027e757e14f54efea\",\"03d72d3de6fad0e4b6e6bb39dcb8a8a2fb3a7fd991a6f88ceb6c0d5324c1cab86c\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03ccf8148c6c7f5a36c01f20492860af41e1159ce9032631c66f067ada77552365",
+      "witness": "{\"signatures\":[\"800f63d6d5a99e762c3cf1313e1669f94691348698ca3fde172227013a0b72a2fdf6f26cb65419a2758ada878fb303f34d2fb47e22f57714a22a244a02fbd0f9\",\"ca625f8721d0b7294f0017a23fcbae76e03c0b6f8abad7b7701de0aea9aead8add3e455da5c8916ff3e25f0365268a42f3293356c929fca8813daabefe365647\",\"6f5f9ce744f6e4ec9dcfb017b0b9d80201ac3cf3cb381926bbdaa22dca0cf9c4b59f49e8bc79b06f88c3b399782ae3c425501babc5a7a61511864733022b6ee7\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"4c1aaceaa62b86d2522f2ad11163347b84c906191067c81102f97ac37e1d3c9f\",\"data\":\"036c270ddd755c185b9be4768ee3d56fb7ed6d6d084e8d0ec0480b947e6b4ffcec\",\"tags\":[[\"pubkeys\",\"02b81f8f01ffe04467ffa6b109c0da9132dcff645f7c19110027e757e14f54efea\",\"03d72d3de6fad0e4b6e6bb39dcb8a8a2fb3a7fd991a6f88ceb6c0d5324c1cab86c\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02a283c0ee98e0321d010170c3b7bc74a53130221fb7fb14c393ce09c50af8f73c"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0238858540b651ef75cd8ee66d8342141e08115e841b28204736f9c903f0f8523a"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "039a51911724a1cc0693494d3cd3e099592713fbc9f4e333f4726de83bee62c4b9"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_more_signatures_than_required label=extra_valid_signatures\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_sigall_refund_multisig_2of2(t *testing.T) {
+	setCompatUnixTime(t, 1781727353)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"f7c7c1cec426171f253ebee2d8e417d2d2e379073b969188b0d8856d796711d9\",\"data\":\"02a3f61cf8d4f6d77c16f689d802a5131a843342f7989d0a19ebd81fbae15f6264\",\"tags\":[[\"locktime\",\"1781727352\"],[\"refund\",\"03d489b0cc07506be87ecd4389fd92ae1fbe004421082ebffee34bc3a6ed320c84\",\"023a67d6b3c0dcd36dee89dcf3965568018a876690798d49b2a22a3c1fa0b9b448\"],[\"n_sigs_refund\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02242443a158798bd237ce2f384ffb8cffbcfe9ae54399dbe2c1c5229cae4d7b48",
+      "witness": "{\"signatures\":[\"dbca92d82655f40a232163e01dda742f04adbca9894b41bbfcfbd3d99d07403e7a65304ed9299d13ca9d8c54d22d555debaf8c619811433d59969253d468be7e\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"f4a78702b4e811cb23561a82160f855c81e477a7a3e4eaaf30c4d2d96cc3d2ac\",\"data\":\"02a3f61cf8d4f6d77c16f689d802a5131a843342f7989d0a19ebd81fbae15f6264\",\"tags\":[[\"locktime\",\"1781727352\"],[\"refund\",\"03d489b0cc07506be87ecd4389fd92ae1fbe004421082ebffee34bc3a6ed320c84\",\"023a67d6b3c0dcd36dee89dcf3965568018a876690798d49b2a22a3c1fa0b9b448\"],[\"n_sigs_refund\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "039ebf1c761de3feffb640f3ab96691420955bc3e906983b625b87f4b0a68e56ff"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03f5f4bf2397d7304142f167f019a9d9835e4a2fe995872c8d73c7792a7d4e24af"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "028ac27168b6ea77377b2d50866e9b5337ae2b81963475388b75b4dc4f63fc6540"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_refund_multisig_2of2 label=1_of_2_refund_multisig\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+
+	payload2 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"f7c7c1cec426171f253ebee2d8e417d2d2e379073b969188b0d8856d796711d9\",\"data\":\"02a3f61cf8d4f6d77c16f689d802a5131a843342f7989d0a19ebd81fbae15f6264\",\"tags\":[[\"locktime\",\"1781727352\"],[\"refund\",\"03d489b0cc07506be87ecd4389fd92ae1fbe004421082ebffee34bc3a6ed320c84\",\"023a67d6b3c0dcd36dee89dcf3965568018a876690798d49b2a22a3c1fa0b9b448\"],[\"n_sigs_refund\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02242443a158798bd237ce2f384ffb8cffbcfe9ae54399dbe2c1c5229cae4d7b48",
+      "witness": "{\"signatures\":[\"34b665963d4329c16feb694f04d991dc588965c532a8647cd11ce518cfb0fd0b8249868bfc6a762adf0398db798cd639c85722a01e242dbe3722145c1e32fd69\",\"acc27d20527f04963c97959d9194b18a0a559dc6efd009c22fcdd377421ee342995ef5e40fd276a6d80f3f050c0d400ae684817b123a01eca74993b1ea743483\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"f4a78702b4e811cb23561a82160f855c81e477a7a3e4eaaf30c4d2d96cc3d2ac\",\"data\":\"02a3f61cf8d4f6d77c16f689d802a5131a843342f7989d0a19ebd81fbae15f6264\",\"tags\":[[\"locktime\",\"1781727352\"],[\"refund\",\"03d489b0cc07506be87ecd4389fd92ae1fbe004421082ebffee34bc3a6ed320c84\",\"023a67d6b3c0dcd36dee89dcf3965568018a876690798d49b2a22a3c1fa0b9b448\"],[\"n_sigs_refund\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "039ebf1c761de3feffb640f3ab96691420955bc3e906983b625b87f4b0a68e56ff"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03f5f4bf2397d7304142f167f019a9d9835e4a2fe995872c8d73c7792a7d4e24af"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "028ac27168b6ea77377b2d50866e9b5337ae2b81963475388b75b4dc4f63fc6540"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_refund_multisig_2of2 label=2_of_2_refund_multisig\n%s", payload2)
+	request2 := decodeSwapRequest(t, payload2)
+	err = validateSwapRequestForCompat(request2)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_p2pk_sigall_output_amounts_swapped_fail(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"2f07af9333c4e9068c0a84a5683bbf4706e267ccc8c03de7964fa5e2ef448c43\",\"data\":\"02eb06c6ffe0c59a49f400939ce885611e8149ad2ab8dc95c737e67b4e8aa1d664\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "026a95b9470ec63a0d69210b4d4980edbc255b16604af75b875979bcc63fd8ae32",
+      "witness": "{\"signatures\":[\"dd0e0abbcb0aa9b8fd2657a0df58b67b175d72e5f4dcab594ab158b33d7ac82730e40db2cf6fa597efbc20b743142cf6c4a33196059197525e5c567d1b032512\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"3684d70094ed848e25680eeddcdf83f2bbcdc5d33146d586bd5a33201a92101d\",\"data\":\"02eb06c6ffe0c59a49f400939ce885611e8149ad2ab8dc95c737e67b4e8aa1d664\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03463cdc5b6fdc8ea1fe610ff3502b6e1e1c6616cf9258f3c280e0147864131b3f"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "021ff6e7905e7dfbe8f3e530bac00fe98ff73fb541365de074bf187e06b9300f72"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03d927f37be1092cf05f1eddaaef49504921c0caff14bf957f3b95083dc716405e"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_output_amounts_swapped_fail label=tampered_output_amounts\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+
+	payload2 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"2f07af9333c4e9068c0a84a5683bbf4706e267ccc8c03de7964fa5e2ef448c43\",\"data\":\"02eb06c6ffe0c59a49f400939ce885611e8149ad2ab8dc95c737e67b4e8aa1d664\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "026a95b9470ec63a0d69210b4d4980edbc255b16604af75b875979bcc63fd8ae32",
+      "witness": "{\"signatures\":[\"dd0e0abbcb0aa9b8fd2657a0df58b67b175d72e5f4dcab594ab158b33d7ac82730e40db2cf6fa597efbc20b743142cf6c4a33196059197525e5c567d1b032512\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"P2PK\",{\"nonce\":\"3684d70094ed848e25680eeddcdf83f2bbcdc5d33146d586bd5a33201a92101d\",\"data\":\"02eb06c6ffe0c59a49f400939ce885611e8149ad2ab8dc95c737e67b4e8aa1d664\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03463cdc5b6fdc8ea1fe610ff3502b6e1e1c6616cf9258f3c280e0147864131b3f"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "021ff6e7905e7dfbe8f3e530bac00fe98ff73fb541365de074bf187e06b9300f72"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03d927f37be1092cf05f1eddaaef49504921c0caff14bf957f3b95083dc716405e"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=p2pk_sigall_output_amounts_swapped_fail label=restored_original_output_amounts\n%s", payload2)
+	request2 := decodeSwapRequest(t, payload2)
+	err = validateSwapRequestForCompat(request2)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_htlc_sigall_preimage_only_no_pubkeys_succeeds(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"2d46b7d8be7adee9ab4d17b4a0fa9261f1eec1f7385a1ee98bda6e120fbd9a66\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0328180ac44627a9138295d38f482c0925385f021c1c35f5106a487eeabf213348",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\"}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"b110d020abc498b1d324bfdcb591f35257a0bde59c3b0a63583d8dee0096ff63\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03728d412c63363b77686dc32dc309b95a05328b2005a7fce324955b1e07bdc152"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03ddbc5b39bb7a563dc2d51b23eed04f66d38bca74664ed899c39e722190b6d0fe"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03babf0f81797a94605746900e5b2e33e1b8914c99a8b271e782119272c69b444f"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_sigall_preimage_only_no_pubkeys_succeeds label=SIG_ALL_HTLC_preimage_only_without_pubkeys\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_htlc_sigall_preimage_only_fails(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"bc045e509f52016662f452114ed823f77e0da4618302649bc48e650b3cc5a72e\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"02a39d309f35bb761eeac69b63eda996b2cac8118c07978b382bba5b450a122952\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03d0f632bb7f2af21de427cbddc6b87b5d49c1b4d510d13cf2945985ec1fb09f32",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\"}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"40617a7c62950875d06128bcb9982939588294d7d758722000113efc0e2bde20\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"02a39d309f35bb761eeac69b63eda996b2cac8118c07978b382bba5b450a122952\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0317bda395bdd0208f72b9825ff4585db97d6d9f67fb776b968af5501a234cd761"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "034af10ab9b2426b965962e102c5813d63c147190b86edf1b319226e65db4f6c58"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02a4138fd1f8da639daad8ae5894deac2fffc42d0c11165f92d9d57db662690f85"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_sigall_preimage_only_fails label=SIG_ALL_HTLC_preimage_only\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+}
+
+func TestCompatibility_htlc_sigall_signature_only_fails(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"c4b0f1d2b34393227cc597ef31e8a176f536c75434460a18d5443c3b79496fcf\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03a4c3d4e6216d3de58cf295d80c7a79d69d0e0b6df90d12339e252916d8e96c55\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03a4c3bf2347aec6ceb5042c88821d436d4e4af74f9e33ee980fd17d32af2d65c7",
+      "witness": "{\"preimage\":\"\",\"signatures\":[\"a1815092dc6df7102a468f1dd402349377d5d8bfb22dd1fa6bacfa234d44e04070e7af5d96ffa2df3f9962e7f6201da8f0eaf134c7dd56d8d29da8f3429563be\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"341cae7c08bfebc0675983ffdfbe41aea421ca421c47862d8d0c7aefe06ad394\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03a4c3d4e6216d3de58cf295d80c7a79d69d0e0b6df90d12339e252916d8e96c55\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0288cf389a170ae16d8a4cd06308c3f53ce5d484b1889e2e9357d9a88e7a2b8462"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02c90d19bb9b4871db1e84909db5712280509a2907d95b14faffbaa5507b82f823"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0312c48e7e4ddbe5f3ab4d4deb2913cd3ddbcc5b06c5d6a401da68c55d257dd96d"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_sigall_signature_only_fails label=SIG_ALL_HTLC_signature_only\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrInvalidPreimage)
+}
+
+func TestCompatibility_htlc_sigall_requires_preimage_and_transaction_signature(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"93ea4e70d5f1324d5fffd089e86de3709e4145ed46b0731e007e043ba0e2416e\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03df39dfa9f3632b675073ba3d81701d9dfc18717619dbf8376617fcdec8a0c0fe\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02c0a62e1d6bb3f98b74ce9647f1ef2a489d4da195b30ad84e1bf6c839f63400be",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"60c91d0a6145bd52d7059359558c120c312253b6cc1a756a76655e1fbe5e1b710c206d94fd4e25a07c9c2b5d5cacb5061644691a3194574c4853331d64b8de02\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"114e6ca96451d559349450b353762702827a2dc0810da6bb758586f8dd2ab1b2\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03df39dfa9f3632b675073ba3d81701d9dfc18717619dbf8376617fcdec8a0c0fe\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0378ba73bb8423398cb46036f15d6d2c3ad64ca1248945065f3add43c3a8af984e"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "032b661c025a0224f74b082c8aaa8f23c8139aba3efa5747436f7c2d13c97dcd55"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "035e65535733607f1ef0d9696ddd36bf3a9aff3e3ca1a284437ed93ff068abfa36"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_sigall_requires_preimage_and_transaction_signature label=SIG_ALL_HTLC_valid_spend\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_htlc_sigall_wrong_preimage_fails(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"bd98f3e8514a9835859c7bc0606d3f8e807c4bd8a27aa95e5181ebedf32be221\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"02f9aff5582e974054033bf8b02ff929945d2dd9ffbe88fc806d3f2f837b504118\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "022668977d292d8a09469a530a30a8bc2cbcac13e2501d0a0b20e7407c9049ec5d",
+      "witness": "{\"preimage\":\"this_is_the_wrong_preimage\",\"signatures\":[\"15c1d4262e0a4fbc43c3cd2a290c70d5fea09921913a7f63c9716eeea922d0fa2027d35ed17588c51c6a1018dd1820b6e2956b36a16013defcb26f46c9b4069c\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"0d4a7560c7242358e95e0083d8051aea49c50f270a7e9aaa38ab2315b86e2655\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"02f9aff5582e974054033bf8b02ff929945d2dd9ffbe88fc806d3f2f837b504118\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0297d374dc55702b74d330987242bc80c21f941919965800832d21a7a2d8970e37"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "03c847febbb213f924446826df6d252fba0cb23608ffb9ef0d6d798ed7f244386e"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "029e3263bf0dbcec369842c0d344808e396b966112c09b8bf1c523e9b4de8de1a7"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_sigall_wrong_preimage_fails label=SIG_ALL_HTLC_wrong_preimage\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrInvalidHexPreimage)
+}
+
+func TestCompatibility_htlc_sigall_locktime_after_expiry_refund_succeeds(t *testing.T) {
+	setCompatUnixTime(t, 1781729955)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"33482ba23eb25ca931a9cb6be48c37d3d5b0757b001059a8b9391ad6251413ee\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"036982e8fcdfe6e3b96992b5428d628192d81adb5053189305a3aef46c359163e0\"],[\"locktime\",\"1781729954\"],[\"refund\",\"0241ec6d7eefab43fd4f8a336acb336957689911a59564d9ff71be070c3f22829f\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "0211629bad1b3ef603af8891f7c4fbe79a2a26679199fd13c66b8cf196826d6971",
+      "witness": "{\"preimage\":\"\",\"signatures\":[\"d6856931c99c2b2516f4687d3dbad5244a9e7db1c499cd97341b3610b177bfd89915eee7259a820453df0840ee6fba30b43074805d9d766d100105bfbe70a2b6\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"b3286541a6f747e19a6b8ca9db349beebf4d0809297c08391af71ee712f04954\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"036982e8fcdfe6e3b96992b5428d628192d81adb5053189305a3aef46c359163e0\"],[\"locktime\",\"1781729954\"],[\"refund\",\"0241ec6d7eefab43fd4f8a336acb336957689911a59564d9ff71be070c3f22829f\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02ee15560b33ddb258aada971a2b52d7c243d04c5a9623168598c2eba259222b60"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0336248e0f8c3bdcf9ebccd6c6ab527dffb43f21a07ae5eb1d520d45e2c1993b82"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02eaa5de5287a84838b5b8fd2b9a5721f6be1ddf38b83a0c8eb601f2ce0cee80cb"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_sigall_locktime_after_expiry_refund_succeeds label=SIG_ALL_HTLC_refund_after_locktime\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_htlc_sigall_multisig_2of3(t *testing.T) {
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"56e61c12b585df27630c6871739cf6438158ef0df94accb4194158c55713a66f\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03152b40a455a50e732741b25ada824fea022c9e352edd943969e41b48ab92226e\",\"029f3140be040ea9b1247585722b9707f74598f1e818d0dfc1217e1047ed48db5e\",\"0204fb683bd3202f5cc1f7edb0b439cb86ee3bf3c500b92336177f292e7d651c7b\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "021d1df1c390e9b79817676fe2e912e842fe6370988cd05dd770f5aa31b6863b7b",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"ede4741a9237388811fecfbc86ed4ad932191d80a17993c834142daf32d34a7a0e181186d029269f13e03783f43616aea2e9ea48adda0d761eab495d99e7d8a5\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"db1214ccd53a1c58bbf92a0f8008fd7f493f82820882429ae9337533d698b768\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03152b40a455a50e732741b25ada824fea022c9e352edd943969e41b48ab92226e\",\"029f3140be040ea9b1247585722b9707f74598f1e818d0dfc1217e1047ed48db5e\",\"0204fb683bd3202f5cc1f7edb0b439cb86ee3bf3c500b92336177f292e7d651c7b\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03e9046db8c959f98720b128a353e248cc4927e4d81d4e83064d838bf8e635b9ab"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02586dcd622936fc6af6628731bf1c24d05d3e7172cc0b56566350030047cf10c9"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02fcf5ec62685c6b97a3c7d00fdc4649779eeba1289547a43838ae1be62275d96d"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_sigall_multisig_2of3 label=SIG_ALL_HTLC_1_of_3\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, ErrNotEnoughSignatures)
+
+	payload2 := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"56e61c12b585df27630c6871739cf6438158ef0df94accb4194158c55713a66f\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03152b40a455a50e732741b25ada824fea022c9e352edd943969e41b48ab92226e\",\"029f3140be040ea9b1247585722b9707f74598f1e818d0dfc1217e1047ed48db5e\",\"0204fb683bd3202f5cc1f7edb0b439cb86ee3bf3c500b92336177f292e7d651c7b\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "021d1df1c390e9b79817676fe2e912e842fe6370988cd05dd770f5aa31b6863b7b",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"5b289bf55a6e264bafd7b257bfcd35920b388a6920816bf954e8062d6c6fb445901982e63ee4377c11193da6185b3ac609dc1f940e512dbd2776a4aa3b109b60\",\"85b9ea0cec695414412289b37ffe4a2348beccc82c5f1ec6eed8279bd1c146a1bc178191edfcefe0efbbdcfef59f7db6d4ad6a5cbcd140ac5cb70d53543c8697\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"db1214ccd53a1c58bbf92a0f8008fd7f493f82820882429ae9337533d698b768\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"03152b40a455a50e732741b25ada824fea022c9e352edd943969e41b48ab92226e\",\"029f3140be040ea9b1247585722b9707f74598f1e818d0dfc1217e1047ed48db5e\",\"0204fb683bd3202f5cc1f7edb0b439cb86ee3bf3c500b92336177f292e7d651c7b\"],[\"n_sigs\",\"2\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "03e9046db8c959f98720b128a353e248cc4927e4d81d4e83064d838bf8e635b9ab"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02586dcd622936fc6af6628731bf1c24d05d3e7172cc0b56566350030047cf10c9"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "02fcf5ec62685c6b97a3c7d00fdc4649779eeba1289547a43838ae1be62275d96d"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_sigall_multisig_2of3 label=SIG_ALL_HTLC_2_of_3\n%s", payload2)
+	request2 := decodeSwapRequest(t, payload2)
+	err = validateSwapRequestForCompat(request2)
+	assertCompatError(t, err, nil)
+}
+
+func TestCompatibility_htlc_sigall_receiver_path_after_locktime(t *testing.T) {
+	setCompatUnixTime(t, 1781729955)
+	payload := []byte(`{
+  "inputs": [
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"19792005ce11bcca9e13695eb3a4a5f4494c67eb0673d20ac1fdffa0387bff5b\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"0268ba663639f7f9cda9d7c4540ec3e05716b34d9b81a092599bd16a8ae109cfc3\"],[\"locktime\",\"1781729954\"],[\"refund\",\"034130d16b7e150956ea691b5a753e9663e8b312682f9ee17543ff796ff62f18d5\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "02a38c7ea9d9be42ec484a79dcd90e9e742afa95cbfc662cd461cf77e4c283c56d",
+      "witness": "{\"preimage\":\"4242424242424242424242424242424242424242424242424242424242424242\",\"signatures\":[\"c07692c985895cd6a6c3691c0a4e9ec1bc646d767017c0a9ab51cd9ca75e29e00e03b46c1a3de901b13a88effddef29b77c4315ee2587bcb7941c3788c7cdff3\"]}"
+    },
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "secret": "[\"HTLC\",{\"nonce\":\"93637545cad534076c36dd487874d15b2ad62ddfad71811c63318bb2af93b4a1\",\"data\":\"425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c\",\"tags\":[[\"pubkeys\",\"0268ba663639f7f9cda9d7c4540ec3e05716b34d9b81a092599bd16a8ae109cfc3\"],[\"locktime\",\"1781729954\"],[\"refund\",\"034130d16b7e150956ea691b5a753e9663e8b312682f9ee17543ff796ff62f18d5\"],[\"sigflag\",\"SIG_ALL\"]]}]",
+      "C": "026b45de7452a17409f104f73d27b7341ae73573b8214754289d3050fc87bc5eb0"
+    }
+  ],
+  "outputs": [
+    {
+      "amount": 2,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0262119d63f0ceeaaa0a92bdba5d95bc61fd033908615fc1fa311cfabc22711394"
+    },
+    {
+      "amount": 8,
+      "id": "0143cd3bb4a53bc6aeca481bb5ee707ea702939c83d9a86541be106c0e3dfcfe52",
+      "B_": "0203312f081329583f39709c0f7eb84f9b7aa8a9393c19dfda9338fcd872d28c32"
+    }
+  ]
+}
+`)
+	t.Logf("scenario=htlc_sigall_receiver_path_after_locktime label=SIG_ALL_HTLC_receiver_after_locktime\n%s", payload)
+	request1 := decodeSwapRequest(t, payload)
+	err := validateSwapRequestForCompat(request1)
+	assertCompatError(t, err, nil)
+}

--- a/api/cashu/melt.go
+++ b/api/cashu/melt.go
@@ -74,8 +74,8 @@ type PostMeltQuoteBolt11Response struct {
 }
 
 type PostMeltBolt11Request struct {
-	Quote   string           `json:"quote"`
-	Inputs  Proofs           `json:"inputs"`
+	Quote   string          `json:"quote"`
+	Inputs  Proofs          `json:"inputs"`
 	Outputs BlindedMessages `json:"outputs"`
 }
 
@@ -86,25 +86,9 @@ func (p *PostMeltBolt11Request) ValidateSigflag() error {
 	}
 	if sigAllCheck.sigFlag == SigAll {
 		firstProof := p.Inputs[0]
-		firstSpendCondition, err := firstProof.parseSpendCondition()
-		if err != nil {
-			return fmt.Errorf("p.Inputs[0].parseSpendCondition(). %w", err)
-		}
-		firstWitness, err := firstProof.parseWitness()
-		if err != nil {
-			return fmt.Errorf("p.Inputs[0].parseWitness(). %w", err)
-		}
-
-		if firstSpendCondition == nil || firstWitness == nil {
-			return ErrInvalidSpendCondition
-		}
-
-		if firstWitness.Signatures == nil {
-			return ErrNoValidSignatures
-		}
 
 		// check the conditions are met
-		err = p.verifyConditions()
+		err = p.verifySigAllRepetition()
 		if err != nil {
 			return fmt.Errorf("p.verifyConditions(). %w", err)
 		}
@@ -112,34 +96,19 @@ func (p *PostMeltBolt11Request) ValidateSigflag() error {
 		// makes message
 		msg := p.makeSigAllMsg()
 
-		signatures, err := checkValidSignature(msg, sigAllCheck.pubkeys, firstWitness.Signatures)
+		err = checkSigAllProofValid(msg, sigAllCheck, firstProof)
 		if err != nil {
-			return fmt.Errorf("checkValidSignature(msg, pubkeys, firstWitness.Signatures). %w", err)
+			return fmt.Errorf("checkSigAllProofValid(msg, sigAllCheck, firstProof). %w", err)
 		}
-		if signatures >= sigAllCheck.signaturesRequired {
-			return nil
-		}
-
-		if firstProof.timelockPassed(firstSpendCondition) {
-			signatures, err := checkValidSignature(msg, sigAllCheck.refundPubkeys, firstWitness.Signatures)
-			if err != nil {
-				return fmt.Errorf("checkValidSignature(msg, refundPubkeys, firstWitness.Signatures). %w", err)
-			}
-			if signatures >= sigAllCheck.signaturesRequiredRefund {
-				return nil
-			}
-		}
-
-		return ErrNotEnoughSignatures
 	}
 	return nil
 }
 
-func (p *PostMeltBolt11Request) verifyConditions() error {
+func (p *PostMeltBolt11Request) verifySigAllRepetition() error {
 	firstProof := p.Inputs[0]
 	firstSpendCondition, err := firstProof.parseSpendCondition()
 	if err != nil {
-		return nil
+		return fmt.Errorf("firstProof.parseSpendCondition(). %w", err)
 	}
 
 	for _, proof := range p.Inputs {

--- a/api/cashu/proofs.go
+++ b/api/cashu/proofs.go
@@ -102,22 +102,23 @@ func (p Proof) verifyP2PKSpendCondition(spendCondition *SpendCondition, witness 
 func (p Proof) VerifyP2PK(spendCondition *SpendCondition) (bool, error) {
 	witness, err := p.parseWitness()
 	if err != nil {
-		return false, fmt.Errorf("p.parseWitness(). %+v", err)
+		return false, fmt.Errorf("p.parseWitness(). %w", err)
 	}
-	valid, err := p.verifyP2PKSpendCondition(spendCondition, witness)
+	valid := false
+	if timelockPassed(spendCondition) {
+		valid, _ = p.verifyTimelockPassedSpendCondition(spendCondition, witness)
+		if valid {
+			return valid, nil
+		}
+	}
+	valid, err = p.verifyP2PKSpendCondition(spendCondition, witness)
 	if err != nil {
 		if errors.Is(err, ErrNoValidSignatures) || errors.Is(err, ErrNotEnoughSignatures) {
 		} else {
 			return false, fmt.Errorf("p.verifyP2PKSpendCondition(spendCondition, witness). %w", err)
 		}
 	}
-	if valid {
-		return true, nil
-	}
-	if p.timelockPassed(spendCondition) {
-		valid, err = p.verifyTimelockPassedSpendCondition(spendCondition, witness)
-	}
-	return valid, err
+	return valid, nil
 }
 
 func (p Proof) verifyHtlcSpendCondition(spendCondition *SpendCondition, witness *Witness) (bool, error) {
@@ -127,7 +128,7 @@ func (p Proof) verifyHtlcSpendCondition(spendCondition *SpendCondition, witness 
 	}
 
 	if len(spendCondition.Data.Tags.Pubkeys) == 0 {
-		return false, ErrInvalidPreimage
+		return true, nil
 	}
 
 	pubkeys, err := p.pubkeysForVerification(spendCondition)
@@ -178,7 +179,16 @@ func (p Proof) VerifyHTLC(spendCondition *SpendCondition) (bool, error) {
 		return false, fmt.Errorf("p.parseWitness(). %+v", err)
 	}
 
-	valid, err := p.verifyHtlcSpendCondition(spendCondition, witness)
+	valid := false
+	if timelockPassed(spendCondition) {
+		valid, _ = p.verifyTimelockPassedSpendCondition(spendCondition, witness)
+
+		if valid {
+			return valid, nil
+		}
+	}
+
+	valid, err = p.verifyHtlcSpendCondition(spendCondition, witness)
 	if err != nil {
 		if errors.Is(err, ErrNoValidSignatures) || errors.Is(err, ErrNotEnoughSignatures) {
 		} else {
@@ -188,13 +198,10 @@ func (p Proof) VerifyHTLC(spendCondition *SpendCondition) (bool, error) {
 	if valid {
 		return true, nil
 	}
-	if p.timelockPassed(spendCondition) {
-		valid, err = p.verifyTimelockPassedSpendCondition(spendCondition, witness)
-	}
 	return valid, err
 }
 
-func (p Proof) timelockPassed(spendCondition *SpendCondition) bool {
+func timelockPassed(spendCondition *SpendCondition) bool {
 	currentTime := time.Now().Unix()
 	return spendCondition.Data.Tags.Locktime != 0 && currentTime > int64(spendCondition.Data.Tags.Locktime)
 }
@@ -227,6 +234,8 @@ func (p Proof) verifyTimelockPassedSpendCondition(spendCondition *SpendCondition
 		}
 	}
 	switch {
+	case nsigToCheck == 0:
+		return true, nil
 	case amountValidSigs == 0:
 		return false, ErrNoValidSignatures
 	case nsigToCheck > 0 && amountValidSigs < nsigToCheck:
@@ -289,15 +298,20 @@ func (p Proof) parseSpendCondition() (*SpendCondition, error) {
 	err := json.Unmarshal([]byte(p.Secret), &spendCondition)
 
 	if err != nil {
-		return nil, fmt.Errorf("json.Unmarshal([]byte(p.Secret), &spendCondition)  %w, %w", ErrCouldNotParseSpendCondition, err)
+		return nil, errors.Join(ErrCouldNotParseSpendCondition, err)
 	}
 	return &spendCondition, nil
 }
 func (p Proof) parseWitness() (*Witness, error) {
 	var witness Witness
+	if len(p.Witness) == 0 {
+		witness.Preimage = ""
+		witness.Signatures = nil
+		return &witness, nil
+	}
 	err := json.Unmarshal([]byte(p.Witness), &witness)
 	if err != nil {
-		return nil, fmt.Errorf("json.Unmarshal([]byte(p.Witness), &witness)  %w, %w", ErrCouldNotParseWitness, err)
+		return nil, errors.Join(ErrCouldNotParseWitness, err)
 	}
 
 	return &witness, nil
@@ -435,41 +449,49 @@ func (p *Proof) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func VerifyProofCondition(proof Proof) error {
+	isLocked, spendCondition, err := proof.IsProofSpendConditioned()
+	if err != nil {
+		return fmt.Errorf("proof.IsProofSpendConditioned(). %+v", err)
+	}
+	if isLocked {
+		err = spendCondition.CheckValid()
+		if err != nil {
+			return fmt.Errorf("spendCondition.CheckValid(). %w", err)
+		}
+		switch spendCondition.Type {
+		case P2PK:
+			valid, err := proof.VerifyP2PK(spendCondition)
+			if err != nil {
+				return fmt.Errorf("proof.VerifyP2PK(spendCondition). %w", err)
+			}
+			if !valid {
+				return ErrInvalidSpendCondition
+			}
+		case HTLC:
+			valid, err := proof.VerifyHTLC(spendCondition)
+			if err != nil {
+				return fmt.Errorf("proof.VerifyHTLC(spendCondition). %w", err)
+			}
+			if !valid {
+				return ErrInvalidSpendCondition
+			}
+		}
+	}
+	if !isLocked {
+		if len(proof.Secret) != 64 {
+			return ErrCommonSecretNotCorrectSize
+		}
+	}
+	return nil
+}
+
 // VerifyProofsSpendConditions verifies P2PK and HTLC conditions for each proof individually.
 func VerifyProofsSpendConditions(proofs Proofs) error {
 	for _, proof := range proofs {
-		isLocked, spendCondition, err := proof.IsProofSpendConditioned()
+		err := VerifyProofCondition(proof)
 		if err != nil {
-			return fmt.Errorf("proof.IsProofSpendConditioned(). %+v", err)
-		}
-		if isLocked {
-			err = spendCondition.CheckValid()
-			if err != nil {
-				return fmt.Errorf("spendCondition.CheckValid(). %w", err)
-			}
-			switch spendCondition.Type {
-			case P2PK:
-				valid, err := proof.VerifyP2PK(spendCondition)
-				if err != nil {
-					return fmt.Errorf("proof.VerifyP2PK(spendCondition). %w", err)
-				}
-				if !valid {
-					return ErrInvalidSpendCondition
-				}
-			case HTLC:
-				valid, err := proof.VerifyHTLC(spendCondition)
-				if err != nil {
-					return fmt.Errorf("proof.VerifyHTLC(spendCondition). %w", err)
-				}
-				if !valid {
-					return ErrInvalidSpendCondition
-				}
-			}
-		}
-		if !isLocked {
-			if len(proof.Secret) != 64 {
-				return ErrCommonSecretNotCorrectSize
-			}
+			return fmt.Errorf("VerifyProofCondition(proof). %w", err)
 		}
 	}
 	return nil

--- a/api/cashu/proofs.go
+++ b/api/cashu/proofs.go
@@ -113,10 +113,7 @@ func (p Proof) VerifyP2PK(spendCondition *SpendCondition) (bool, error) {
 	}
 	valid, err = p.verifyP2PKSpendCondition(spendCondition, witness)
 	if err != nil {
-		if errors.Is(err, ErrNoValidSignatures) || errors.Is(err, ErrNotEnoughSignatures) {
-		} else {
-			return false, fmt.Errorf("p.verifyP2PKSpendCondition(spendCondition, witness). %w", err)
-		}
+		return false, fmt.Errorf("p.verifyP2PKSpendCondition(spendCondition, witness). %w", err)
 	}
 	return valid, nil
 }
@@ -190,10 +187,7 @@ func (p Proof) VerifyHTLC(spendCondition *SpendCondition) (bool, error) {
 
 	valid, err = p.verifyHtlcSpendCondition(spendCondition, witness)
 	if err != nil {
-		if errors.Is(err, ErrNoValidSignatures) || errors.Is(err, ErrNotEnoughSignatures) {
-		} else {
-			return false, fmt.Errorf("p.verifyP2PKSpendCondition(spendCondition, witness). %w", err)
-		}
+		return false, fmt.Errorf("p.verifyHtlcSpendCondition(spendCondition, witness). %w", err)
 	}
 	if valid {
 		return true, nil

--- a/api/cashu/proofs.go
+++ b/api/cashu/proofs.go
@@ -176,7 +176,7 @@ func (p Proof) verifyHtlcSpendCondition(spendCondition *SpendCondition, witness 
 func (p Proof) VerifyHTLC(spendCondition *SpendCondition) (bool, error) {
 	witness, err := p.parseWitness()
 	if err != nil {
-		return false, fmt.Errorf("p.parseWitness(). %+v", err)
+		return false, fmt.Errorf("p.parseWitness(). %w", err)
 	}
 
 	valid := false
@@ -351,7 +351,7 @@ func (p Proof) HashSecretToCurve() (Proof, error) {
 	y, err := crypto.HashToCurve(parsedProof)
 
 	if err != nil {
-		return p, fmt.Errorf("crypto.HashToCurve: %+v", err)
+		return p, fmt.Errorf("crypto.HashToCurve: %w", err)
 	}
 
 	p.Y = WrappedPublicKey{y}
@@ -452,7 +452,7 @@ func (p *Proof) UnmarshalJSON(data []byte) error {
 func VerifyProofCondition(proof Proof) error {
 	isLocked, spendCondition, err := proof.IsProofSpendConditioned()
 	if err != nil {
-		return fmt.Errorf("proof.IsProofSpendConditioned(). %+v", err)
+		return fmt.Errorf("proof.IsProofSpendConditioned(). %w", err)
 	}
 	if isLocked {
 		err = spendCondition.CheckValid()

--- a/api/cashu/proofs_test.go
+++ b/api/cashu/proofs_test.go
@@ -241,7 +241,7 @@ func TestCheckP2PKProofInvalidLocktimeRefundKey(t *testing.T) {
 	}
 
 	valid, err := proof.VerifyP2PK(spendCondition)
-	if !errors.Is(err, ErrNoValidSignatures) {
+	if !errors.Is(err, ErrNotEnoughSignatures) {
 		t.Errorf("Error should be about no valid signatures. %+v", err)
 	}
 	if valid {

--- a/api/cashu/spend_condition.go
+++ b/api/cashu/spend_condition.go
@@ -365,8 +365,8 @@ func TagFromString(s string) (Tags, error) {
 type SigFlag int
 
 const (
-	SigAll    SigFlag = iota + 1 // 1
-	SigInputs SigFlag = iota + 2 // 2
+	SigAll SigFlag = iota + 1 // 1
+	SigInputs
 )
 
 func (sf SigFlag) String() string {

--- a/api/cashu/spend_condition.go
+++ b/api/cashu/spend_condition.go
@@ -302,13 +302,11 @@ func (scd *SpendConditionData) MarshalJSON() ([]byte, error) {
 
 func (sc *SpendCondition) VerifyPreimage(witness *Witness) error {
 	preImageBytes, err := hex.DecodeString(witness.Preimage)
-
 	if err != nil {
 		return errors.Join(ErrInvalidHexPreimage, err)
 	}
 
 	parsedPreimage := sha256.Sum256(preImageBytes)
-
 	if hex.EncodeToString(parsedPreimage[:]) != sc.Data.Data {
 		return ErrInvalidPreimage
 	}
@@ -368,7 +366,7 @@ type SigFlag int
 
 const (
 	SigAll    SigFlag = iota + 1 // 1
-	SigInputs                    // 2
+	SigInputs SigFlag = iota + 2 // 2
 )
 
 func (sf SigFlag) String() string {
@@ -466,6 +464,7 @@ type SigflagValidation struct {
 	pubkeys                  map[string]struct{}
 	refundPubkeys            map[string]struct{}
 	sigFlag                  SigFlag
+	proofType                SpendConditionType
 	signaturesRequired       uint
 	signaturesRequiredRefund uint
 }
@@ -473,8 +472,9 @@ type SigflagValidation struct {
 func checkForSigAll(proofs Proofs) (SigflagValidation, error) {
 	sigflagValidation := SigflagValidation{
 		sigFlag:                  SigInputs,
-		signaturesRequired:       1,
+		signaturesRequired:       0,
 		signaturesRequiredRefund: 0,
+		proofType:                AnyOneCanSpend,
 		pubkeys:                  make(map[string]struct{}),
 		refundPubkeys:            make(map[string]struct{}),
 	}
@@ -486,12 +486,19 @@ func checkForSigAll(proofs Proofs) (SigflagValidation, error) {
 		if isLocked && spendCondition != nil {
 			if spendCondition.Data.Tags.Sigflag == SigAll {
 				sigflagValidation.sigFlag = SigAll
+				sigflagValidation.proofType = spendCondition.Type
+				if spendCondition.Type == P2PK {
+					sigflagValidation.signaturesRequired = 1
+				}
 				if spendCondition.Data.Tags.NSigs > 1 {
 					sigflagValidation.signaturesRequired = spendCondition.Data.Tags.NSigs
 				}
 				pubkeys, err := proof.pubkeysForVerification(spendCondition)
 				if err != nil {
 					return SigflagValidation{}, fmt.Errorf("proof.pubkeysForVerification(spendCondition). %w", err)
+				}
+				if len(pubkeys) > 0 && sigflagValidation.signaturesRequired == 0 {
+					sigflagValidation.signaturesRequired = 1
 				}
 
 				sigflagValidation.pubkeys = pubkeys
@@ -524,7 +531,53 @@ func ProofsHaveSigAll(proofs Proofs) (bool, error) {
 	return false, nil
 }
 
-func checkValidSignature(msg string, pubkeys map[string]struct{}, signatures []*schnorr.Signature) (uint, error) {
+func checkSigAllProofValid(sigAllMsg string, sigAllValidation SigflagValidation, firstProof Proof) error {
+	if sigAllValidation.sigFlag != SigAll {
+		return fmt.Errorf("sigAllValidation has flag that is not SIG_ALL")
+	}
+
+	spendCondition, err := firstProof.parseSpendCondition()
+	if err != nil {
+		return fmt.Errorf("firstProof.parseSpendCondition(). %w", err)
+	}
+	witness, err := firstProof.parseWitness()
+	if err != nil {
+		return fmt.Errorf("firstProof.parseWitness(). %w", err)
+	}
+
+	if spendCondition == nil || witness == nil {
+		return ErrInvalidSpendCondition
+	}
+
+	if timelockPassed(spendCondition) {
+		signatures, err := checkSigAllValidSignature(sigAllMsg, sigAllValidation.refundPubkeys, witness.Signatures)
+		if err != nil {
+			return fmt.Errorf("checkSigAllValidSignature(msg, refundPubkeys, firstWitness.Signatures). %w", err)
+		}
+		if signatures >= sigAllValidation.signaturesRequiredRefund {
+			return nil
+		}
+	}
+	if sigAllValidation.proofType == HTLC {
+		err := spendCondition.VerifyPreimage(witness)
+		if err != nil {
+			return fmt.Errorf("spendCondition.VerifyPreimage(witness). %w", err)
+		}
+	}
+
+	signatures, err := checkSigAllValidSignature(sigAllMsg, sigAllValidation.pubkeys, witness.Signatures)
+	if err != nil {
+		return fmt.Errorf("checkSigAllValidSignature(msg, pubkeys, firstWitness.Signatures). %w", err)
+	}
+
+	if signatures < sigAllValidation.signaturesRequired {
+		return ErrNotEnoughSignatures
+	}
+
+	return nil
+}
+
+func checkSigAllValidSignature(msg string, pubkeys map[string]struct{}, signatures []*schnorr.Signature) (uint, error) {
 	hashMessage := sha256.Sum256([]byte(msg))
 	amountValidSigs := uint(0)
 

--- a/api/cashu/spend_condition_test.go
+++ b/api/cashu/spend_condition_test.go
@@ -423,7 +423,7 @@ func TestVectorRefundSigInvalidFromFuture(t *testing.T) {
 	if valid != false {
 		t.Error("proof should be valid")
 	}
-	if !errors.Is(err, ErrNoValidSignatures) {
+	if !errors.Is(err, ErrNotEnoughSignatures) {
 		t.Errorf("Error should be ErrNotEnoughSignatures. %+v", err)
 	}
 }

--- a/api/cashu/swap.go
+++ b/api/cashu/swap.go
@@ -30,43 +30,24 @@ func (p *PostSwapRequest) ValidateSigflag() error {
 			return ErrInvalidSpendCondition
 		}
 
-		if firstWitness.Signatures == nil {
-			return ErrNoValidSignatures
-		}
-
 		// check the conditions are met
-		err = p.verifyConditions()
+		err = p.verifySigAllRepetition()
 		if err != nil {
-			return fmt.Errorf("p.verifyConditions(). %w", err)
+			return fmt.Errorf("p.verifySigAllRepetition(). %w", err)
 		}
 
 		// makes message
 		msg := p.makeSigAllMsg()
 
-		signatures, err := checkValidSignature(msg, sigAllCheck.pubkeys, firstWitness.Signatures)
+		err = checkSigAllProofValid(msg, sigAllCheck, firstProof)
 		if err != nil {
-			return fmt.Errorf("checkValidSignature(msg, pubkeys, firstWitness.Signatures). %w", err)
+			return fmt.Errorf("checkSigAllProofValid(msg, sigAllCheck, firstProof). %w", err)
 		}
-		if signatures >= sigAllCheck.signaturesRequired {
-			return nil
-		}
-
-		if firstProof.timelockPassed(firstSpendCondition) {
-			signatures, err := checkValidSignature(msg, sigAllCheck.refundPubkeys, firstWitness.Signatures)
-			if err != nil {
-				return fmt.Errorf("checkValidSignature(msg, refundPubkeys, firstWitness.Signatures). %w", err)
-			}
-			if signatures >= sigAllCheck.signaturesRequiredRefund {
-				return nil
-			}
-		}
-
-		return ErrNotEnoughSignatures
 	}
 	return nil
 }
 
-func (p *PostSwapRequest) verifyConditions() error {
+func (p *PostSwapRequest) verifySigAllRepetition() error {
 	firstProof := p.Inputs[0]
 	firstSpendCondition, err := firstProof.parseSpendCondition()
 	if err != nil {

--- a/cmd/nutmix/main.go
+++ b/cmd/nutmix/main.go
@@ -180,10 +180,21 @@ func main() {
 	srv.ReadTimeout = 3 * time.Second
 	srv.WriteTimeout = 4 * time.Second
 	srv.IdleTimeout = 3 * time.Minute
-	// Start the server
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		slog.Error("server failed", slog.Any("error", err))
-		os.Exit(1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("server failed", slog.Any("error", err))
+			os.Exit(1)
+		}
+	}()
+
+	<-appCtx.Done()
+	slog.Info("Shutting down server...")
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		slog.Error("server forced to shutdown", slog.Any("error", err))
 	}
 }
 

--- a/cmd/nutmix/main.go
+++ b/cmd/nutmix/main.go
@@ -207,20 +207,20 @@ func GetSignerFromValue(signerType string, db database.MintDB) (signer.Signer, e
 	case MemorySigner:
 		signer, err := localsigner.SetupLocalSigner(db)
 		if err != nil {
-			return &signer, fmt.Errorf("localsigner.SetupLocalSigner(db): %+v ", err)
+			return &signer, fmt.Errorf("localsigner.SetupLocalSigner(db): %w", err)
 		}
 		return &signer, nil
 	case AbstractSocketSigner:
 		signer, err := remoteSigner.SetupRemoteSigner(false, os.Getenv("NETWORK_SIGNER_ADDRESS"))
 		if err != nil {
-			return &signer, fmt.Errorf("socketremotesigner.SetupSocketSigner(): %+v ", err)
+			return &signer, fmt.Errorf("socketremotesigner.SetupSocketSigner(): %w", err)
 		}
 		return &signer, nil
 
 	case NetworkSigner:
 		signer, err := remoteSigner.SetupRemoteSigner(true, os.Getenv("NETWORK_SIGNER_ADDRESS"))
 		if err != nil {
-			return &signer, fmt.Errorf("socketremotesigner.SetupSocketSigner(): %+v ", err)
+			return &signer, fmt.Errorf("socketremotesigner.SetupSocketSigner(): %w", err)
 		}
 		return &signer, nil
 

--- a/internal/database/postgresql/operations_test.go
+++ b/internal/database/postgresql/operations_test.go
@@ -42,7 +42,7 @@ func TestAddAndRequestMintRequestValidPubkey(t *testing.T) {
 
 	connUri, err := postgresContainer.ConnectionString(ctx)
 	if err != nil {
-		t.Fatal(fmt.Errorf("failed to get connection string: %v", err))
+		t.Fatal(fmt.Errorf("failed to get connection string: %w", err))
 	}
 
 	t.Setenv("DATABASE_URL", connUri)
@@ -149,7 +149,7 @@ func TestAddAndRequestMintRequestNilPubkey(t *testing.T) {
 
 	connUri, err := postgresContainer.ConnectionString(ctx)
 	if err != nil {
-		t.Fatal(fmt.Errorf("failed to get connection string: %v", err))
+		t.Fatal(fmt.Errorf("failed to get connection string: %w", err))
 	}
 
 	t.Setenv("DATABASE_URL", connUri)
@@ -678,7 +678,7 @@ func setupTestDB(t *testing.T) (Postgresql, context.Context) {
 
 	connUri, err := postgresContainer.ConnectionString(ctx)
 	if err != nil {
-		t.Fatal(fmt.Errorf("failed to get connection string: %v", err))
+		t.Fatal(fmt.Errorf("failed to get connection string: %w", err))
 	}
 
 	t.Setenv("DATABASE_URL", connUri)

--- a/internal/lightning/cln.go
+++ b/internal/lightning/cln.go
@@ -31,7 +31,7 @@ func getTlsConfig(clientCert string, clientKey string, caCert string) (*tls.Conf
 	if clientCert != "" && clientKey != "" {
 		cert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientKey))
 		if err != nil {
-			return tlsConfig, fmt.Errorf("\n error loading X.509 key pair: %v", err)
+			return tlsConfig, fmt.Errorf("\n error loading X.509 key pair: %w", err)
 		}
 		tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
 	}
@@ -61,7 +61,7 @@ func (l *CLNGRPCWallet) SetupGrpc(host string, caCert string, clientCert string,
 
 	tlsConfig, err := getTlsConfig(clientCert, clientKey, caCert)
 	if err != nil {
-		return fmt.Errorf("getTlsConfig(clientCert, clientKey, tlsCrt) %v", err)
+		return fmt.Errorf("getTlsConfig(clientCert, clientKey, tlsCrt) %w", err)
 	}
 
 	certFile := credentials.NewTLS(tlsConfig)

--- a/internal/mint/mint_test.go
+++ b/internal/mint/mint_test.go
@@ -103,12 +103,12 @@ func SetupDataOnDB(mint *Mint) error {
 
 	c1Priv, err := secp256k1.GeneratePrivateKey()
 	if err != nil {
-		return fmt.Errorf("secp256k1.GeneratePrivateKey: %+v ", err)
+		return fmt.Errorf("secp256k1.GeneratePrivateKey: %w", err)
 	}
 	c1 := c1Priv.PubKey()
 	c2Priv, err := secp256k1.GeneratePrivateKey()
 	if err != nil {
-		return fmt.Errorf("secp256k1.GeneratePrivateKey: %+v ", err)
+		return fmt.Errorf("secp256k1.GeneratePrivateKey: %w", err)
 	}
 
 	c2 := c2Priv.PubKey()
@@ -150,7 +150,7 @@ func SetupDataOnDB(mint *Mint) error {
 
 	tx, err := mint.MintDB.GetTx(ctx)
 	if err != nil {
-		return fmt.Errorf("mint.MintDB.GetTx(ctx): %+v ", err)
+		return fmt.Errorf("mint.MintDB.GetTx(ctx): %w", err)
 	}
 	defer func() {
 		_ = mint.MintDB.Rollback(ctx, tx)
@@ -158,17 +158,17 @@ func SetupDataOnDB(mint *Mint) error {
 
 	err = mint.MintDB.SaveMeltRequest(tx, melt_quote)
 	if err != nil {
-		return fmt.Errorf("mint.MintDB.SaveMeltRequest(tx, melt_quote): %+v ", err)
+		return fmt.Errorf("mint.MintDB.SaveMeltRequest(tx, melt_quote): %w", err)
 	}
 
 	err = mint.MintDB.SaveProof(tx, proofs)
 	if err != nil {
-		return fmt.Errorf("mint.MintDB.SaveProof(tx, proofs): %+v ", err)
+		return fmt.Errorf("mint.MintDB.SaveProof(tx, proofs): %w", err)
 	}
 	//
 	err = mint.MintDB.Commit(ctx, tx)
 	if err != nil {
-		return fmt.Errorf("mint.MintDB.Commit(ctx, tx): %+v ", err)
+		return fmt.Errorf("mint.MintDB.Commit(ctx, tx): %w", err)
 	}
 
 	return nil

--- a/internal/routes/admin/auth.go
+++ b/internal/routes/admin/auth.go
@@ -120,7 +120,12 @@ func LoginPost(mint *mint.Mint, loginKey *secp256k1.PrivateKey, adminNostrPubkey
 
 		defer func() {
 			if p := recover(); p != nil {
-				_ = c.Error(fmt.Errorf("rolling back because of failure %+v", err))
+				recoveredErr, ok := p.(error)
+				if ok {
+					_ = c.Error(fmt.Errorf("rolling back because of failure: %w", recoveredErr))
+				} else {
+					_ = c.Error(fmt.Errorf("rolling back because of failure: %v", p))
+				}
 				rollbackErr := mint.MintDB.Rollback(ctx, tx)
 				if rollbackErr != nil {
 					if !errors.Is(rollbackErr, pgx.ErrTxClosed) {
@@ -128,7 +133,7 @@ func LoginPost(mint *mint.Mint, loginKey *secp256k1.PrivateKey, adminNostrPubkey
 					}
 				}
 			} else if err != nil {
-				_ = c.Error(fmt.Errorf("rolling back because of failure %+v", err))
+				_ = c.Error(fmt.Errorf("rolling back because of failure: %w", err))
 				rollbackErr := mint.MintDB.Rollback(ctx, tx)
 				if rollbackErr != nil {
 					if !errors.Is(rollbackErr, pgx.ErrTxClosed) {
@@ -138,7 +143,7 @@ func LoginPost(mint *mint.Mint, loginKey *secp256k1.PrivateKey, adminNostrPubkey
 			} else {
 				err = mint.MintDB.Commit(ctx, tx)
 				if err != nil {
-					_ = c.Error(fmt.Errorf("failed to commit transaction: %+v", err))
+					_ = c.Error(fmt.Errorf("failed to commit transaction: %w", err))
 				}
 			}
 		}()
@@ -209,7 +214,7 @@ func makeJWTToken(secret []byte) (string, error) {
 	token := jwt.New(jwt.SigningMethodHS256)
 	string, err := token.SignedString(secret)
 	if err != nil {
-		return "", fmt.Errorf("token.SignedString(secret) %v", err)
+		return "", fmt.Errorf("token.SignedString(secret) %w", err)
 	}
 	return string, nil
 }

--- a/internal/routes/admin/liquidity-manager.go
+++ b/internal/routes/admin/liquidity-manager.go
@@ -226,13 +226,18 @@ func SwapOutRequest(mint *m.Mint) gin.HandlerFunc {
 
 		defer func() {
 			if p := recover(); p != nil {
-				_ = c.Error(fmt.Errorf("rolling back because of failure %+v", err))
+				recoveredErr, ok := p.(error)
+				if ok {
+					_ = c.Error(fmt.Errorf("rolling back because of failure: %w", recoveredErr))
+				} else {
+					_ = c.Error(fmt.Errorf("rolling back because of failure: %v", p))
+				}
 				rollbackErr := mint.MintDB.Rollback(ctx, tx)
 				if rollbackErr != nil {
 					slog.Warn("Failed to rollback transaction", slog.Any("error", rollbackErr))
 				}
 			} else if err != nil {
-				_ = c.Error(fmt.Errorf("rolling back because of failure %+v", err))
+				_ = c.Error(fmt.Errorf("rolling back because of failure: %w", err))
 				rollbackErr := mint.MintDB.Rollback(ctx, tx)
 				if rollbackErr != nil {
 					slog.Warn("Failed to rollback transaction", slog.Any("error", rollbackErr))
@@ -244,7 +249,7 @@ func SwapOutRequest(mint *m.Mint) gin.HandlerFunc {
 		if err != nil {
 			// If the fees are acceptable, continue to create the Receive Payment
 			log.Printf("\n Could not add swap request %+v \n", err)
-			_ = c.Error(fmt.Errorf("could not add swap request %+v", err))
+			_ = c.Error(fmt.Errorf("could not add swap request: %w", err))
 			return
 		}
 		err = mint.MintDB.Commit(c.Request.Context(), tx)
@@ -303,7 +308,7 @@ func SwapInRequest(mint *m.Mint, newLiquidity chan string) gin.HandlerFunc {
 		if err != nil {
 			// If the fees are acceptable, continue to create the Receive Payment
 			log.Printf("\n zpay32.Decode(resp.PaymentRequest, %+v \n", err)
-			_ = c.Error(fmt.Errorf("zpay32.Decode(resp.PaymentRequest): %+v", err))
+			_ = c.Error(fmt.Errorf("zpay32.Decode(resp.PaymentRequest): %w", err))
 			return
 		}
 
@@ -330,13 +335,18 @@ func SwapInRequest(mint *m.Mint, newLiquidity chan string) gin.HandlerFunc {
 
 		defer func() {
 			if p := recover(); p != nil {
-				_ = c.Error(fmt.Errorf("rolling back because of failure %+v", err))
+				recoveredErr, ok := p.(error)
+				if ok {
+					_ = c.Error(fmt.Errorf("rolling back because of failure: %w", recoveredErr))
+				} else {
+					_ = c.Error(fmt.Errorf("rolling back because of failure: %v", p))
+				}
 				rollbackErr := mint.MintDB.Rollback(ctx, tx)
 				if rollbackErr != nil {
 					slog.Warn("Failed to rollback transaction", slog.Any("error", rollbackErr))
 				}
 			} else if err != nil {
-				_ = c.Error(fmt.Errorf("rolling back because of failure %+v", err))
+				_ = c.Error(fmt.Errorf("rolling back because of failure: %w", err))
 				rollbackErr := mint.MintDB.Rollback(ctx, tx)
 				if rollbackErr != nil {
 					slog.Warn("Failed to rollback transaction", slog.Any("error", rollbackErr))
@@ -348,7 +358,7 @@ func SwapInRequest(mint *m.Mint, newLiquidity chan string) gin.HandlerFunc {
 		if err != nil {
 			// If the fees are acceptable, continue to create the Receive Payment
 			log.Printf("\n Could not add swap request %+v \n", err)
-			_ = c.Error(fmt.Errorf("could not add swap request %+v", err))
+			_ = c.Error(fmt.Errorf("could not add swap request: %w", err))
 			return
 		}
 		err = mint.MintDB.Commit(c.Request.Context(), tx)
@@ -397,13 +407,18 @@ func SwapStateCheck(mint *m.Mint) gin.HandlerFunc {
 
 		defer func() {
 			if p := recover(); p != nil {
-				_ = c.Error(fmt.Errorf("rolling back because of failure %+v", err))
+				recoveredErr, ok := p.(error)
+				if ok {
+					_ = c.Error(fmt.Errorf("rolling back because of failure: %w", recoveredErr))
+				} else {
+					_ = c.Error(fmt.Errorf("rolling back because of failure: %v", p))
+				}
 				rollbackErr := mint.MintDB.Rollback(ctx, tx)
 				if rollbackErr != nil {
 					slog.Warn("Failed to rollback transaction", slog.Any("error", rollbackErr))
 				}
 			} else if err != nil {
-				_ = c.Error(fmt.Errorf("rolling back because of failure %+v", err))
+				_ = c.Error(fmt.Errorf("rolling back because of failure: %w", err))
 				rollbackErr := mint.MintDB.Rollback(ctx, tx)
 				if rollbackErr != nil {
 					slog.Warn("Failed to rollback transaction", slog.Any("error", rollbackErr))
@@ -454,13 +469,18 @@ func ConfirmSwapOutTransaction(mint *m.Mint, newLiquidity chan string) gin.Handl
 
 		defer func() {
 			if p := recover(); p != nil {
-				_ = c.Error(fmt.Errorf("rolling back because of failure %+v", err))
+				recoveredErr, ok := p.(error)
+				if ok {
+					_ = c.Error(fmt.Errorf("rolling back because of failure: %w", recoveredErr))
+				} else {
+					_ = c.Error(fmt.Errorf("rolling back because of failure: %v", p))
+				}
 				rollbackErr := mint.MintDB.Rollback(ctx, tx)
 				if rollbackErr != nil {
 					slog.Warn("Failed to rollback transaction", slog.Any("error", rollbackErr))
 				}
 			} else if err != nil {
-				_ = c.Error(fmt.Errorf("rolling back because of failure %+v", err))
+				_ = c.Error(fmt.Errorf("rolling back because of failure: %w", err))
 				rollbackErr := mint.MintDB.Rollback(ctx, tx)
 				if rollbackErr != nil {
 					slog.Warn("Failed to rollback transaction", slog.Any("error", rollbackErr))

--- a/internal/routes/admin/pages.go
+++ b/internal/routes/admin/pages.go
@@ -281,12 +281,17 @@ func SwapStatusPage(mint *mint.Mint) gin.HandlerFunc {
 
 		defer func() {
 			if p := recover(); p != nil {
-				_ = c.Error(fmt.Errorf("rolling back because of failure %+v", err))
+				recoveredErr, ok := p.(error)
+				if ok {
+					_ = c.Error(fmt.Errorf("rolling back because of failure: %w", recoveredErr))
+				} else {
+					_ = c.Error(fmt.Errorf("rolling back because of failure: %v", p))
+				}
 				if rollbackErr := mint.MintDB.Rollback(ctx, tx); rollbackErr != nil {
 					slog.Error("Failed to rollback transaction", slog.Any("error", rollbackErr))
 				}
 			} else if err != nil {
-				_ = c.Error(fmt.Errorf("rolling back because of failure %+v", err))
+				_ = c.Error(fmt.Errorf("rolling back because of failure: %w", err))
 				if rollbackErr := mint.MintDB.Rollback(ctx, tx); rollbackErr != nil {
 					slog.Error("Failed to rollback transaction", slog.Any("error", rollbackErr))
 				}

--- a/internal/utils/proofs.go
+++ b/internal/utils/proofs.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -18,7 +19,7 @@ func ParseErrorToCashuErrorCode(proofError error) (cashu.ErrorCode, *string) {
 	case errors.Is(proofError, cashu.ErrEmptyWitness):
 
 		message := "Empty Witness"
-		return cashu.UNKNOWN, &message
+		return cashu.PROOF_VERIFICATION_FAILED, &message
 
 	case errors.Is(proofError, cashu.ErrPaymentNoRoute):
 		message := "No route found for payment"
@@ -53,9 +54,6 @@ func ParseErrorToCashuErrorCode(proofError error) (cashu.ErrorCode, *string) {
 		message := cashu.ErrMintRequestAlreadyIssued.Error()
 		return cashu.QUOTE_ALREADY_ISSUED, &message
 
-	case errors.Is(proofError, cashu.ErrLocktimePassed):
-		message := cashu.ErrLocktimePassed.Error()
-		return cashu.UNKNOWN, &message
 	case errors.Is(proofError, cashu.ErrUsingInactiveKeyset):
 		return cashu.INACTIVE_KEYSET, nil
 	case errors.Is(proofError, cashu.ErrMeltAlreadyPaid):
@@ -136,6 +134,7 @@ func ParseErrorToCashuErrorCode(proofError error) (cashu.ErrorCode, *string) {
 		return cashu.PROOF_VERIFICATION_FAILED, &message
 	}
 
+	slog.Error("UNKNOWN error detected. This should have not happened", slog.Any("error", proofError))
 	return cashu.UNKNOWN, nil
 }
 


### PR DESCRIPTION
Adds fixes for parsing and securing proofs that are locked with sig_all and other complex systems